### PR TITLE
fix: use ConfigDict for Pydantic V2 compatibility

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -200,13 +200,12 @@ class TiltUpdate(BaseModel):
 
 
 class TiltResponse(TiltBase):
+    model_config = ConfigDict(from_attributes=True)
+
     id: str
     mac: Optional[str]
     original_gravity: Optional[float]
     last_seen: Optional[datetime]
-
-    class Config:
-        from_attributes = True
 
 
 class TiltReading(BaseModel):
@@ -222,6 +221,8 @@ class TiltReading(BaseModel):
 
 
 class ReadingResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     timestamp: datetime
     sg_raw: Optional[float]
@@ -231,21 +232,19 @@ class ReadingResponse(BaseModel):
     rssi: Optional[int]
     status: Optional[str] = None  # 'valid', 'invalid', 'uncalibrated', 'incomplete'
 
-    class Config:
-        from_attributes = True
-
 
 class AmbientReadingResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     timestamp: datetime
     temperature: Optional[float]
     humidity: Optional[float]
 
-    class Config:
-        from_attributes = True
-
 
 class ControlEventResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     timestamp: datetime
     tilt_id: Optional[str]
@@ -253,9 +252,6 @@ class ControlEventResponse(BaseModel):
     wort_temp: Optional[float]
     ambient_temp: Optional[float]
     target_temp: Optional[float]
-
-    class Config:
-        from_attributes = True
 
 
 class CalibrationPointCreate(BaseModel):
@@ -265,13 +261,12 @@ class CalibrationPointCreate(BaseModel):
 
 
 class CalibrationPointResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     type: str
     raw_value: float
     actual_value: float
-
-    class Config:
-        from_attributes = True
 
 
 class ConfigUpdate(BaseModel):

--- a/backend/routers/devices.py
+++ b/backend/routers/devices.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -100,6 +100,8 @@ class DeviceUpdate(BaseModel):
 
 class DeviceResponse(BaseModel):
     """Schema for device response."""
+    model_config = ConfigDict(from_attributes=True)
+
     id: str
     device_type: str
     name: str
@@ -117,9 +119,6 @@ class DeviceResponse(BaseModel):
     color: Optional[str]
     mac: Optional[str]
     created_at: datetime
-
-    class Config:
-        from_attributes = True
 
     @classmethod
     def from_orm_with_calibration(cls, device: Device) -> "DeviceResponse":


### PR DESCRIPTION
## Summary
- Replace deprecated class-based `Config` with `model_config = ConfigDict()` in all response models
- Eliminates Pydantic V2 deprecation warnings that would break in V3

## Changes
- `backend/models.py`: Updated 5 models (TiltResponse, ReadingResponse, AmbientReadingResponse, ControlEventResponse, CalibrationPointResponse)
- `backend/routers/devices.py`: Updated DeviceResponse model

## Test plan
- [x] All 121 tests pass
- [x] No Pydantic deprecation warnings in test output

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)