### PR TITLE
feat: batch lifecycle tabs - phase-aware batch detail UI

### DIFF
--- a/docs/plans/2026-02-09-batch-lifecycle-tabs-design.md
+++ b/docs/plans/2026-02-09-batch-lifecycle-tabs-design.md
@@ -1,0 +1,243 @@
+# Batch Lifecycle Tabs — Design Document
+
+**Date:** 2026-02-09
+**Status:** Draft
+
+## Problem
+
+The batch detail page (`/batches/[id]`) is a 1200+ line monolithic component with conditional rendering per status. All phases share the same layout, leading to:
+
+1. **Wrong context in wrong phase** — ML predictions show "will appear once fermentation is underway" during conditioning. Fermentation ETA shows during conditioning. Rate-of-change stats are meaningless post-fermentation.
+2. **No recipe-driven guidance** — Recipes already define fermentation steps (primary/secondary/conditioning with durations and temperatures) but the UI doesn't use them to guide the user through phases.
+3. **Tasting journal buried** — The guided tasting system (designed in `2026-02-02-guided-tasting-design.md`) should be a primary feature during conditioning, not hidden.
+4. **No transition prompts** — The user must manually change status. The app has ML predictions and sensor data that could suggest when to advance.
+
+## Design
+
+### URL & Navigation
+
+**URL stays the same:** `/batches/[id]`
+
+**Page layout:**
+```
+┌──────────────────────────────────────────────────┐
+│ Batch Header (name, recipe link, started date)   │
+│                                                  │
+│ ● Recipe → ● Brew Day → ● Ferm → ○ Cond → ○ Done│  ← lifecycle stepper
+├──────────────────────────────────────────────────┤
+│ [Recipe] [Brew Day] [Fermentation] [Conditioning]│  ← phase tabs
+├──────────────────────────────────────────────────┤
+│                                                  │
+│  Phase-specific content (one component per tab)  │
+│                                                  │
+├──────────────────────────────────────────────────┤
+│ ┌──────────────────────────────────────────────┐ │
+│ │ ⚡ Gravity stable 48h — Ready to condition?  │ │  ← transition prompt
+│ │                          [Not Yet] [Advance] │ │
+│ └──────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────┘
+```
+
+### Lifecycle Stepper
+
+A horizontal progress indicator above the tabs:
+
+- **Completed phases:** Filled circle + checkmark, clickable to view that tab
+- **Current phase:** Highlighted/pulsing, active tab
+- **Future phases:** Greyed out circles, tabs visible but show "Not started yet" placeholder
+- Phases: Recipe → Brew Day → Fermentation → Conditioning → Complete
+- Maps to statuses: `planning` → `brewing` → `fermenting` → `conditioning` → `completed`
+
+**Default tab on load:** The tab matching the batch's current status.
+
+### Phase Tab Components
+
+Extract the existing conditional rendering into focused components:
+
+#### `PhaseRecipe.svelte`
+- Recipe targets card (OG, FG, IBU, ABV, SRM, color)
+- Ingredient summary (fermentables, hops, cultures, misc)
+- Fermentation schedule from recipe steps (primary X days at Y°C → conditioning Z days at W°C)
+- Mash schedule summary
+- Water profile if defined
+- **Action:** "Start Brew Day" button → transitions to `brewing`
+
+#### `PhaseBrewDay.svelte`
+- BrewDayTimer (hop additions, mash steps from recipe)
+- BrewDayChecklist (recipe-driven process steps)
+- BrewDayObservations (notes, pre-boil gravity, volumes)
+- Pre-pitch chilling progress (if device paired + target temp set)
+- OG recording
+- **Action:** "Yeast Pitched — Start Fermentation" button → transitions to `fermenting`
+
+#### `PhaseFermentation.svelte`
+- **Left column:**
+  - BatchFermentationCard (live gravity + temp hero, progress bar OG→FG)
+  - Recipe target comparison (where we are vs recipe expectations)
+  - Fermentation chart (full historical chart with SG, temps, trend lines)
+  - FermentationStats bar (rate, duration, at SG, OG, attenuation, ABV, ETA)
+- **Right column:**
+  - MLPredictions (active mode — predicted FG, model selection, confidence, anomalies, stuck warnings)
+  - BatchAlertsCard
+  - Temperature control card (if HA configured)
+  - Notes
+- **Recipe-driven:** Shows expected duration from recipe fermentation step (`type=primary`), e.g., "Day 8 of 14 (recipe target)"
+- **Transition prompt:** When ML predicts FG reached + gravity stable for configurable period → banner: "Fermentation appears complete — ready to condition?"
+
+#### `PhaseConditioning.svelte`
+- **Left column:**
+  - **Conditioning Progress Card**
+    - Reads from recipe `fermentation_steps` where `type = 'conditioning'`
+    - "Day 3 of 14 at 5.0°C" — recipe-defined duration and temp
+    - Sub-phase timeline: Diacetyl Rest → Cold Crash → Packaging Ready
+    - Diacetyl rest: derived from yeast type (lager strains) or recipe step
+    - Cold crash: recipe conditioning temp, suggested 24–72h if not specified
+    - If no conditioning step in recipe, prompt user to add one or use style defaults
+  - **Final Fermentation Summary** (collapsed card)
+    - OG, FG, ABV, Attenuation — locked-in final numbers
+    - Compact, read-only — fermentation is done
+  - **Tasting Journal** (prominent, primary activity)
+    - LLM-assisted guided tasting (per `2026-02-02-guided-tasting-design.md`)
+    - "Start Guided Tasting" button or manual BJCP form
+    - Timeline of tasting entries showing beer evolution over conditioning
+    - This is a first-class citizen here, not a collapsible afterthought
+- **Right column:**
+  - Temperature control card (critical for cold crash management)
+  - Conditioning checklist / guidance (recipe-aware suggestions)
+  - Notes
+- **Stats bar changes:**
+  - Drop: ETA, Rate (meaningless post-fermentation)
+  - Keep: Duration, OG, FG, ABV, Attenuation
+  - Add: Conditioning day count, days remaining to recipe target ready date
+- **Transition prompt:** When conditioning duration target reached → "Conditioning target reached — ready to package?"
+
+#### `PhaseComplete.svelte`
+- Batch summary card (final OG, FG, ABV, Attenuation, total duration)
+- Phase timeline showing all transitions with dates
+- ML post-mortem (prediction accuracy: predicted vs actual FG)
+- Packaging info (keg/bottle, carbonation, date)
+- Reflections & learnings section
+- Full tasting journal history (read-only, showing evolution)
+- Full fermentation chart (historical, read-only)
+
+### Shared Elements
+
+These remain visible across all tabs (in the batch header area or always-accessible):
+
+- Batch name, recipe link, status badge, started date
+- Lifecycle stepper (always shows where you are)
+- Edit/Pause/Delete actions
+
+The fermentation chart could optionally appear as a collapsible on non-fermentation tabs for quick reference.
+
+### Transition Prompts
+
+**Prompt by default, auto-advance as future opt-in.**
+
+Transition conditions detected by the system:
+
+| Transition | Condition |
+|---|---|
+| Brewing → Fermenting | User clicks "Yeast Pitched" (manual, no auto-detect) |
+| Fermenting → Conditioning | ML predicts FG reached AND gravity stable for N hours (configurable, default 48h) |
+| Conditioning → Completed | Recipe conditioning duration elapsed OR user decides |
+
+**Prompt UI:** A banner at the bottom of the phase content (not a modal — non-blocking). Includes:
+- What was detected ("Gravity stable for 48h at 1.004")
+- Suggested action ("Ready to start conditioning?")
+- Two buttons: "Not Yet" (dismiss, re-prompts later) and "Advance to Conditioning"
+
+**Future (opt-in):** Auto-advance setting per batch or globally. When enabled, the system advances automatically and logs the transition with reason.
+
+### Recipe-Driven Phase Awareness
+
+The recipe's `fermentation_steps` table drives the lifecycle:
+
+```
+fermentation_steps:
+  - step_number: 1, type: "primary",      temp_c: 20.0, time_days: 14
+  - step_number: 2, type: "secondary",    temp_c: 18.0, time_days: 7
+  - step_number: 3, type: "conditioning",  temp_c: 5.0,  time_days: 14
+```
+
+Each phase tab reads its targets from the matching step:
+- PhaseFermentation reads `type=primary` (and `type=secondary` if present)
+- PhaseConditioning reads `type=conditioning`
+- Duration countdowns, temperature targets, and progress all derive from recipe data
+
+**Fallback for missing data:** If a recipe has no fermentation steps defined, show sensible defaults based on style (ale vs lager) and prompt user to define them in the recipe.
+
+### MLPredictions Adaptation
+
+The MLPredictions component needs phase-aware behavior:
+
+| Phase | ML Behavior |
+|---|---|
+| Planning/Brewing | Hidden or shows "ML activates during fermentation" |
+| Fermenting | Full active mode (current behavior) — predictions, anomalies, model selection |
+| Conditioning | Hidden or shows compact summary: "Final prediction accuracy: ±2 points" |
+| Completed | Post-mortem mode (current behavior) — accuracy comparison |
+
+### FermentationStats Bar Adaptation
+
+| Phase | Stats Shown |
+|---|---|
+| Fermenting | Rate, Duration, At SG, OG, Attenuation, ABV, ETA (current behavior) |
+| Conditioning | Duration (conditioning), OG, FG, ABV, Attenuation, Days Remaining |
+| Completed | Total Duration, OG, FG, ABV, Attenuation |
+
+## Implementation Strategy
+
+### Phase 1: Extract Tab Components (refactor, no new features)
+1. Create `PhaseRecipe.svelte`, `PhaseBrewDay.svelte`, `PhaseFermentation.svelte`, `PhaseConditioning.svelte`, `PhaseComplete.svelte`
+2. Move existing conditional blocks from `+page.svelte` into respective components
+3. Add tab navigation UI to `+page.svelte`
+4. Add lifecycle stepper component
+5. Default to current-status tab on load
+6. **Outcome:** Same functionality, cleaner architecture, ~200-400 lines per component instead of 1200+
+
+### Phase 2: Conditioning Differentiation
+1. Build conditioning progress card reading recipe fermentation steps
+2. Adapt FermentationStats bar for conditioning (drop ETA/Rate, add conditioning day count)
+3. Make tasting journal prominent in conditioning tab
+4. Adapt MLPredictions to hide/summarize during conditioning
+5. Add cold crash / diacetyl rest sub-phase guidance
+
+### Phase 3: Recipe-Driven Guidance
+1. Show recipe-defined durations as targets in each phase ("Day 8 of 14")
+2. Add fermentation step awareness to temperature control suggestions
+3. Fallback defaults when recipe steps are missing
+
+### Phase 4: Transition Prompts
+1. Detect fermentation completion (stable gravity + ML prediction match)
+2. Detect conditioning duration reached
+3. Show non-blocking transition prompt banners
+4. Log transitions with detected reason
+
+### Future: Auto-Advance (opt-in)
+- Per-batch or global setting
+- Auto-transitions with logged reasons
+- Notification when auto-advanced
+
+## Files Affected
+
+### New Files
+- `frontend/src/lib/components/batch/PhaseRecipe.svelte`
+- `frontend/src/lib/components/batch/PhaseBrewDay.svelte`
+- `frontend/src/lib/components/batch/PhaseFermentation.svelte`
+- `frontend/src/lib/components/batch/PhaseConditioning.svelte`
+- `frontend/src/lib/components/batch/PhaseComplete.svelte`
+- `frontend/src/lib/components/batch/LifecycleStepper.svelte`
+- `frontend/src/lib/components/batch/TransitionPrompt.svelte`
+- `frontend/src/lib/components/batch/ConditioningProgress.svelte`
+
+### Modified Files
+- `frontend/src/routes/batches/[id]/+page.svelte` — gut conditional blocks, add tab/stepper navigation
+- `frontend/src/lib/components/batch/MLPredictions.svelte` — phase-aware rendering
+- `frontend/src/lib/components/FermentationStats.svelte` — phase-aware stats
+- Backend: Possibly add transition detection endpoint or WebSocket event
+
+### No Schema Changes Required
+- Recipe `fermentation_steps` already exists with `type`, `temp_c`, `time_days`
+- Batch status flow already supports all phases
+- No new database tables needed

--- a/docs/plans/2026-02-09-batch-lifecycle-tabs-impl.md
+++ b/docs/plans/2026-02-09-batch-lifecycle-tabs-impl.md
@@ -1,0 +1,644 @@
+# Batch Lifecycle Tabs — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refactor the monolithic 2583-line batch detail page into tabbed phase components with a lifecycle stepper.
+
+**Architecture:** Extract existing conditional rendering blocks from `+page.svelte` into dedicated phase components. Add tab navigation and a lifecycle stepper. No new features — pure refactor that preserves all existing functionality while establishing the architecture for future phase-specific enhancements.
+
+**Tech Stack:** SvelteKit 5, Svelte 5 runes ($state, $derived, $props), TypeScript
+
+**Worktree:** `/home/ladmin/Projects/brewsignal/brewsignal-web/.worktrees/lifecycle-tabs/`
+
+---
+
+## Task Overview
+
+Tasks 1-6 are independent (new component files) and can be parallelized.
+Task 7 depends on all of 1-6 (wires everything together in the page).
+
+---
+
+### Task 1: Create LifecycleStepper Component
+
+**Files:**
+- Create: `frontend/src/lib/components/batch/LifecycleStepper.svelte`
+
+**What it does:** Horizontal progress stepper showing the batch lifecycle phases. Completed phases get checkmarks, current phase is highlighted, future phases are greyed out.
+
+**Step 1: Create the component**
+
+```svelte
+<script lang="ts">
+	import type { BatchStatus } from '$lib/api';
+	import { statusConfig } from '$lib/components/status';
+
+	interface Props {
+		currentStatus: BatchStatus;
+	}
+
+	let { currentStatus }: Props = $props();
+
+	const phases: { status: BatchStatus; label: string }[] = [
+		{ status: 'planning', label: 'Recipe' },
+		{ status: 'brewing', label: 'Brew Day' },
+		{ status: 'fermenting', label: 'Fermentation' },
+		{ status: 'conditioning', label: 'Conditioning' },
+		{ status: 'completed', label: 'Complete' },
+	];
+
+	const statusOrder: Record<string, number> = {
+		planning: 0,
+		brewing: 1,
+		fermenting: 2,
+		conditioning: 3,
+		completed: 4,
+		archived: 4,
+	};
+
+	let currentIndex = $derived(statusOrder[currentStatus] ?? 0);
+
+	function getPhaseState(phaseIndex: number): 'completed' | 'current' | 'future' {
+		if (phaseIndex < currentIndex) return 'completed';
+		if (phaseIndex === currentIndex) return 'current';
+		return 'future';
+	}
+</script>
+
+<div class="lifecycle-stepper">
+	{#each phases as phase, i}
+		{@const state = getPhaseState(i)}
+		{#if i > 0}
+			<div class="connector" class:completed={i <= currentIndex}></div>
+		{/if}
+		<div class="step" class:completed={state === 'completed'} class:current={state === 'current'} class:future={state === 'future'}>
+			<div class="step-dot">
+				{#if state === 'completed'}
+					<svg class="check-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+					</svg>
+				{/if}
+			</div>
+			<span class="step-label">{phase.label}</span>
+		</div>
+	{/each}
+</div>
+```
+
+Styles: horizontal flex layout, dots connected by lines, completed=green with checkmark, current=accent color with pulse, future=muted. Use CSS variables from the existing theme (`var(--positive)`, `var(--accent)`, `var(--text-muted)`, `var(--border-subtle)`).
+
+**Step 2: Verify build**
+
+Run: `cd frontend && npm run check`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add frontend/src/lib/components/batch/LifecycleStepper.svelte
+git commit -m "feat: add LifecycleStepper component for batch lifecycle navigation"
+```
+
+---
+
+### Task 2: Create PhaseRecipe Component
+
+**Files:**
+- Create: `frontend/src/lib/components/batch/PhaseRecipe.svelte`
+
+**What it does:** Extract lines 575-606 of `+page.svelte` (planning phase). Shows "Ready to Brew?" action card and recipe targets.
+
+**Step 1: Create the component**
+
+Extract the planning phase block. Props needed:
+- `batch: BatchResponse` — for recipe access
+- `statusUpdating: boolean` — for button disabled state
+- `onStartBrewDay: () => void` — callback for the button
+
+```svelte
+<script lang="ts">
+	import type { BatchResponse } from '$lib/api';
+	import BatchRecipeTargetsCard from './BatchRecipeTargetsCard.svelte';
+
+	interface Props {
+		batch: BatchResponse;
+		statusUpdating: boolean;
+		onStartBrewDay: () => void;
+	}
+
+	let { batch, statusUpdating, onStartBrewDay }: Props = $props();
+</script>
+```
+
+Template: Copy the `{#if batch.status === 'planning'}` block (lines 575-606) into this component's template, removing the outer `{#if}` since the parent controls which phase is shown. Replace `handleStartBrewDay` with `onStartBrewDay`.
+
+Styles: Copy `.phase-action-card`, `.phase-icon`, `.phase-title`, `.phase-description`, `.start-brewday-btn`, `.btn-spinner`, `.btn-icon` from `+page.svelte` styles.
+
+**Step 2: Verify build**
+
+Run: `cd frontend && npm run check`
+
+**Step 3: Commit**
+
+```bash
+git add frontend/src/lib/components/batch/PhaseRecipe.svelte
+git commit -m "feat: extract PhaseRecipe component from batch detail page"
+```
+
+---
+
+### Task 3: Create PhaseBrewDay Component
+
+**Files:**
+- Create: `frontend/src/lib/components/batch/PhaseBrewDay.svelte`
+
+**What it does:** Extract lines 608-736 of `+page.svelte` (brewing phase). Shows brew day tools, chilling progress, pitch button.
+
+**Step 1: Create the component**
+
+Props needed:
+- `batch: BatchResponse`
+- `liveReading: TiltReading | null`
+- `statusUpdating: boolean`
+- `onStartFermentation: () => void`
+- `onEdit: () => void` — for device card edit button
+
+The component needs several derived values that are currently in the page script. Move these INTO the component:
+- `isPrePitchChilling` (line 70-72)
+- `pitchTempReached` (lines 75-78)
+- `chillingProgress` (lines 81-93)
+
+```svelte
+<script lang="ts">
+	import type { BatchResponse } from '$lib/api';
+	import type { TiltReading } from '$lib/stores/tilts.svelte';
+	import { formatTemp, getTempUnit, configState } from '$lib/stores/config.svelte';
+	import BrewDayTimer from './BrewDayTimer.svelte';
+	import BrewDayChecklist from './BrewDayChecklist.svelte';
+	import BrewDayObservations from './BrewDayObservations.svelte';
+	import BatchDeviceCard from './BatchDeviceCard.svelte';
+	import BatchRecipeTargetsCard from './BatchRecipeTargetsCard.svelte';
+
+	interface Props {
+		batch: BatchResponse;
+		liveReading: TiltReading | null;
+		statusUpdating: boolean;
+		onStartFermentation: () => void;
+		onEdit: () => void;
+		onBatchUpdate: (updated: BatchResponse) => void;
+	}
+
+	let { batch, liveReading, statusUpdating, onStartFermentation, onEdit, onBatchUpdate }: Props = $props();
+
+	let tempUnit = $derived(getTempUnit());
+
+	// Move derived values from page
+	let isPrePitchChilling = $derived(
+		(batch.status === 'planning' || batch.status === 'brewing') && batch.temp_target != null
+	);
+
+	let pitchTempReached = $derived.by(() => {
+		if (!isPrePitchChilling || !liveReading?.temp || !batch.temp_target) return false;
+		return liveReading.temp <= batch.temp_target;
+	});
+
+	let chillingProgress = $derived.by(() => {
+		if (!isPrePitchChilling || !liveReading?.temp || !batch.temp_target) return null;
+		const estimatedStartTemp = batch.temp_target + 30;
+		const currentTemp = liveReading.temp;
+		const targetTemp = batch.temp_target;
+		if (currentTemp <= targetTemp) return 100;
+		if (currentTemp >= estimatedStartTemp) return 0;
+		const progress = ((estimatedStartTemp - currentTemp) / (estimatedStartTemp - targetTemp)) * 100;
+		return Math.min(100, Math.max(0, progress));
+	});
+
+	function formatTempValue(value?: number | null): string {
+		if (value === undefined || value === null) return '--';
+		return formatTemp(value);
+	}
+</script>
+```
+
+Template: Copy lines 608-736 (the `{:else if batch.status === 'brewing'}` block), removing outer condition. Replace direct function calls with prop callbacks. Replace `batch = updated` with `onBatchUpdate(updated)`.
+
+Styles: Copy all brewing-phase related styles (`.brewing-phase`, `.phase-action-card.brewing`, `.phase-action-card.chilling`, `.phase-action-card.ready-to-pitch`, `.chilling-temp-display`, `.chilling-progress`, `.brewday-tools-grid`, `.start-fermentation-btn`, etc.)
+
+**Step 2: Verify build**
+
+Run: `cd frontend && npm run check`
+
+**Step 3: Commit**
+
+```bash
+git add frontend/src/lib/components/batch/PhaseBrewDay.svelte
+git commit -m "feat: extract PhaseBrewDay component from batch detail page"
+```
+
+---
+
+### Task 4: Create PhaseFermentation Component
+
+**Files:**
+- Create: `frontend/src/lib/components/batch/PhaseFermentation.svelte`
+
+**What it does:** Extract the fermenting-specific parts from lines 922-1170. This is the current `{:else}` block which handles both fermenting AND conditioning — we split it so this one only handles fermenting.
+
+**Step 1: Create the component**
+
+Props needed:
+- `batch: BatchResponse`
+- `progress: BatchProgressResponse | null`
+- `liveReading: TiltReading | null`
+- `controlStatus: BatchControlStatus | null`
+- `controlEvents: ControlEvent[]`
+- `hasTempControl: boolean`
+- `heaterLoading: boolean`
+- `tempControlCollapsed: boolean`
+- `onOverride: (deviceType: 'heater' | 'cooler', state: 'on' | 'off' | null) => void`
+- `onClearOverrides: () => void`
+- `onTempControlToggle: () => void`
+
+```svelte
+<script lang="ts">
+	import type { BatchResponse, BatchProgressResponse, BatchControlStatus, ControlEvent } from '$lib/api';
+	import type { TiltReading } from '$lib/stores/tilts.svelte';
+	import { formatTemp, getTempUnit, configState } from '$lib/stores/config.svelte';
+	import BatchFermentationCard from './BatchFermentationCard.svelte';
+	import BatchRecipeTargetsCard from './BatchRecipeTargetsCard.svelte';
+	import BatchAlertsCard from './BatchAlertsCard.svelte';
+	import MLPredictions from './MLPredictions.svelte';
+	import BatchNotesCard from './BatchNotesCard.svelte';
+	import FermentationChart from '../FermentationChart.svelte';
+
+	// ... props and derived values
+</script>
+```
+
+Template: Copy the content-grid (lines 924-1132) — the two-column layout with:
+- Left: BatchFermentationCard, BatchRecipeTargetsCard
+- Right: BatchAlertsCard, MLPredictions, Temperature Control Card, Notes
+- Below: FermentationChart
+
+Do NOT include the conditioning tasting journal block (lines 1134-1169).
+
+Styles: Copy `.content-grid`, `.stats-section`, `.info-section`, `.info-card`, `.temp-control-card`, all temperature control styles, `.chart-section`.
+
+**Step 2: Verify build**
+
+Run: `cd frontend && npm run check`
+
+**Step 3: Commit**
+
+```bash
+git add frontend/src/lib/components/batch/PhaseFermentation.svelte
+git commit -m "feat: extract PhaseFermentation component from batch detail page"
+```
+
+---
+
+### Task 5: Create PhaseConditioning Component
+
+**Files:**
+- Create: `frontend/src/lib/components/batch/PhaseConditioning.svelte`
+
+**What it does:** For Phase 1 (refactor only), this starts as a copy of PhaseFermentation but includes the tasting journal section from lines 1134-1169 prominently (not collapsed at bottom).
+
+**Step 1: Create the component**
+
+Same props as PhaseFermentation, plus:
+- `tastingNotes: TastingNote[]`
+- `tastingLoading: boolean`
+
+Template: Same two-column layout as fermentation, but:
+- Left column: BatchFermentationCard, BatchRecipeTargetsCard, then **Tasting Journal section** (moved up from bottom, not collapsible)
+- Right column: MLPredictions, Temperature Control Card, Notes
+- Below: FermentationChart
+
+The tasting journal here should NOT be in a collapsible section — it's a primary element during conditioning. Copy the TastingNotesList rendering from lines 1134-1169 but without the collapsible wrapper.
+
+**Step 2: Verify build**
+
+Run: `cd frontend && npm run check`
+
+**Step 3: Commit**
+
+```bash
+git add frontend/src/lib/components/batch/PhaseConditioning.svelte
+git commit -m "feat: extract PhaseConditioning component from batch detail page"
+```
+
+---
+
+### Task 6: Create PhaseComplete Component
+
+**Files:**
+- Create: `frontend/src/lib/components/batch/PhaseComplete.svelte`
+
+**What it does:** Extract lines 738-920 of `+page.svelte` (completed phase). Shows batch summary, timeline, packaging, reflections, tasting journal.
+
+**Step 1: Create the component**
+
+Props needed:
+- `batch: BatchResponse`
+- `reflections: BatchReflection[]`
+- `tastingNotes: TastingNote[]`
+- `reflectionsLoading: boolean`
+- `tastingLoading: boolean`
+- `onBatchUpdate: (updated: BatchResponse) => void`
+- `onTastingNotesReload: () => void`
+
+Also needs these helper functions (copy from page script):
+- `formatSG` (line 378-381)
+- `formatDate` (lines 406-414)
+
+```svelte
+<script lang="ts">
+	import type { BatchResponse } from '$lib/api';
+	import type { BatchReflection } from '$lib/types/reflection';
+	import type { TastingNote } from '$lib/types/tasting';
+	import { formatGravity } from '$lib/stores/config.svelte';
+	import PackagingInfo from './PackagingInfo.svelte';
+	import TastingNotes from './TastingNotes.svelte';
+	import TastingNotesList from './TastingNotesList.svelte';
+	import ReflectionCard from './ReflectionCard.svelte';
+	import BatchNotesCard from './BatchNotesCard.svelte';
+
+	// ... props
+	// ... local state for expand/collapse
+	let reflectionsExpanded = $state(true);
+	let tastingExpanded = $state(true);
+</script>
+```
+
+Template: Copy lines 738-920, the entire `{:else if batch.status === 'completed'}` block. Remove outer condition.
+
+Styles: Copy `.completed-phase`, `.batch-summary-card`, `.summary-title`, `.summary-stats`, `.summary-stat`, `.stat-label`, `.stat-value`, `.timeline-card`, `.timeline-*`, `.postmortem-section`, `.section-header`, `.section-*`, `.reflections-grid`, `.add-first-btn`.
+
+**Step 2: Verify build**
+
+Run: `cd frontend && npm run check`
+
+**Step 3: Commit**
+
+```bash
+git add frontend/src/lib/components/batch/PhaseComplete.svelte
+git commit -m "feat: extract PhaseComplete component from batch detail page"
+```
+
+---
+
+### Task 7: Refactor +page.svelte with Tab Navigation
+
+**Depends on:** Tasks 1-6
+
+**Files:**
+- Modify: `frontend/src/routes/batches/[id]/+page.svelte`
+
+**What it does:** Replace the conditional phase blocks with tab navigation + the new phase components. This is the integration task.
+
+**Step 1: Add imports and tab state**
+
+At top of script, add:
+```typescript
+import LifecycleStepper from '$lib/components/batch/LifecycleStepper.svelte';
+import PhaseRecipe from '$lib/components/batch/PhaseRecipe.svelte';
+import PhaseBrewDay from '$lib/components/batch/PhaseBrewDay.svelte';
+import PhaseFermentation from '$lib/components/batch/PhaseFermentation.svelte';
+import PhaseConditioning from '$lib/components/batch/PhaseConditioning.svelte';
+import PhaseComplete from '$lib/components/batch/PhaseComplete.svelte';
+```
+
+Add tab state:
+```typescript
+type PhaseTab = 'planning' | 'brewing' | 'fermenting' | 'conditioning' | 'completed';
+
+const tabConfig: { status: PhaseTab; label: string }[] = [
+	{ status: 'planning', label: 'Recipe' },
+	{ status: 'brewing', label: 'Brew Day' },
+	{ status: 'fermenting', label: 'Fermentation' },
+	{ status: 'conditioning', label: 'Conditioning' },
+	{ status: 'completed', label: 'Complete' },
+];
+
+// Active tab defaults to current batch status
+let activeTab = $state<PhaseTab>('planning');
+
+// When batch loads or status changes, default to current phase tab
+$effect(() => {
+	if (batch?.status) {
+		const status = batch.status === 'archived' ? 'completed' : batch.status;
+		activeTab = status as PhaseTab;
+	}
+});
+```
+
+**Step 2: Replace template**
+
+Replace the entire phase-specific content block (lines 574-1170) with:
+
+```svelte
+<!-- Lifecycle Stepper -->
+<LifecycleStepper currentStatus={batch.status} />
+
+<!-- Phase Tabs -->
+<div class="phase-tabs">
+	{#each tabConfig as tab}
+		{@const statusOrder = { planning: 0, brewing: 1, fermenting: 2, conditioning: 3, completed: 4 }}
+		{@const currentOrder = statusOrder[batch.status === 'archived' ? 'completed' : batch.status] ?? 0}
+		{@const tabOrder = statusOrder[tab.status]}
+		<button
+			type="button"
+			class="phase-tab"
+			class:active={activeTab === tab.status}
+			class:future={tabOrder > currentOrder}
+			onclick={() => activeTab = tab.status}
+		>
+			{tab.label}
+		</button>
+	{/each}
+</div>
+
+<!-- Phase Content -->
+<div class="phase-content">
+	{#if activeTab === 'planning'}
+		<PhaseRecipe {batch} {statusUpdating} onStartBrewDay={handleStartBrewDay} />
+	{:else if activeTab === 'brewing'}
+		<PhaseBrewDay
+			{batch}
+			{liveReading}
+			{statusUpdating}
+			onStartFermentation={handleStartFermentation}
+			onEdit={() => (isEditing = true)}
+			onBatchUpdate={(updated) => batch = updated}
+		/>
+	{:else if activeTab === 'fermenting'}
+		<PhaseFermentation
+			{batch}
+			{progress}
+			{liveReading}
+			{controlStatus}
+			{controlEvents}
+			{hasTempControl}
+			{heaterLoading}
+			{tempControlCollapsed}
+			onOverride={handleOverride}
+			onClearOverrides={handleClearAllOverrides}
+			onTempControlToggle={() => tempControlCollapsed = !tempControlCollapsed}
+		/>
+	{:else if activeTab === 'conditioning'}
+		<PhaseConditioning
+			{batch}
+			{progress}
+			{liveReading}
+			{controlStatus}
+			{controlEvents}
+			{hasTempControl}
+			{heaterLoading}
+			{tempControlCollapsed}
+			{tastingNotes}
+			{tastingLoading}
+			onOverride={handleOverride}
+			onClearOverrides={handleClearAllOverrides}
+			onTempControlToggle={() => tempControlCollapsed = !tempControlCollapsed}
+		/>
+	{:else if activeTab === 'completed'}
+		<PhaseComplete
+			{batch}
+			{reflections}
+			{tastingNotes}
+			{reflectionsLoading}
+			{tastingLoading}
+			onBatchUpdate={(updated) => batch = updated}
+			onTastingNotesReload={loadTastingNotes}
+		/>
+	{/if}
+</div>
+```
+
+**Step 3: Remove extracted code**
+
+Remove from `+page.svelte`:
+- The old conditional blocks (lines 574-1170)
+- The derived values moved to PhaseBrewDay (`isPrePitchChilling`, `pitchTempReached`, `chillingProgress`)
+- Styles that were moved to phase components
+- Old component imports that are no longer directly used (BrewDayTimer, BrewDayChecklist, etc.)
+
+Keep in `+page.svelte`:
+- All state declarations (batch, progress, controlStatus, etc.)
+- All async functions (loadBatch, handleStatusChange, handleOverride, etc.)
+- WebSocket logic
+- Batch header, loading/error states, delete modal
+- Readings paused banner (shared across fermenting/conditioning)
+
+**Step 4: Add tab styles**
+
+```css
+.phase-tabs {
+	display: flex;
+	gap: 0;
+	border-bottom: 1px solid var(--border-subtle);
+	margin-bottom: 1.5rem;
+	overflow-x: auto;
+}
+
+.phase-tab {
+	padding: 0.75rem 1rem;
+	font-size: 0.8125rem;
+	font-weight: 500;
+	color: var(--text-muted);
+	background: none;
+	border: none;
+	border-bottom: 2px solid transparent;
+	cursor: pointer;
+	transition: all 0.15s ease;
+	white-space: nowrap;
+}
+
+.phase-tab:hover:not(.future) {
+	color: var(--text-secondary);
+}
+
+.phase-tab.active {
+	color: var(--accent);
+	border-bottom-color: var(--accent);
+}
+
+.phase-tab.future {
+	opacity: 0.4;
+	cursor: default;
+}
+```
+
+**Step 5: Verify build**
+
+Run: `cd frontend && npm run check`
+Expected: No errors, all types resolved
+
+**Step 6: Visual verification**
+
+Run: `cd frontend && npm run dev`
+Manually verify:
+- Planning batch shows Recipe tab active
+- Fermenting batch shows Fermentation tab active
+- Can click between tabs
+- All existing functionality preserved
+
+**Step 7: Commit**
+
+```bash
+git add frontend/src/routes/batches/[id]/+page.svelte
+git commit -m "feat: refactor batch detail page with lifecycle tabs and phase components"
+```
+
+---
+
+### Task 8: Load data for all phase tabs
+
+**Depends on:** Task 7
+
+**Files:**
+- Modify: `frontend/src/routes/batches/[id]/+page.svelte`
+
+**What it does:** Currently `loadBatch()` only loads progress for fermenting/conditioning/completed and reflections/tasting for completed/conditioning. Since users can now click back to view any phase, we should load progress and related data more eagerly.
+
+**Step 1: Update loadBatch**
+
+Change the conditional loading in `loadBatch()` (lines 118-149) to always load progress if the batch has ever been in fermentation (i.e., status is fermenting, conditioning, or completed). Also load reflections/tasting for all post-fermentation batches.
+
+This is a minor change — just ensure the existing conditionals still cover the tab switching scenario. The current logic should already work since it checks the batch status, not which tab is active.
+
+**Step 2: Verify and commit**
+
+```bash
+git commit -m "fix: ensure batch data loads for all accessible phase tabs"
+```
+
+---
+
+## Parallelization Guide
+
+```
+Tasks 1-6: ALL PARALLEL (independent new files)
+   ├── Task 1: LifecycleStepper
+   ├── Task 2: PhaseRecipe
+   ├── Task 3: PhaseBrewDay
+   ├── Task 4: PhaseFermentation
+   ├── Task 5: PhaseConditioning
+   └── Task 6: PhaseComplete
+         │
+         ▼
+Task 7: Refactor +page.svelte (depends on 1-6)
+         │
+         ▼
+Task 8: Data loading adjustments (depends on 7)
+```
+
+## Important Notes
+
+- **Working in worktree:** All paths are relative to `/home/ladmin/Projects/brewsignal/brewsignal-web/.worktrees/lifecycle-tabs/`
+- **No backend changes:** This is purely frontend refactoring
+- **Preserve all styles:** Each phase component must carry its own styles (copied from `+page.svelte`). Don't lose any existing styling.
+- **Svelte 5 runes:** Use `$state`, `$derived`, `$props`, `$effect` — NOT legacy `let x = ...` reactive declarations
+- **Type imports:** Use `import type { ... }` for type-only imports
+- **Build check:** `cd frontend && npm run check` is the verification command (svelte-check)

--- a/frontend/src/lib/components/batch/LifecycleStepper.svelte
+++ b/frontend/src/lib/components/batch/LifecycleStepper.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+	import type { BatchStatus } from '$lib/api';
+
+	interface Props {
+		currentStatus: BatchStatus;
+	}
+
+	let { currentStatus }: Props = $props();
+
+	const phases: { label: string; shortLabel: string; status: BatchStatus }[] = [
+		{ label: 'Recipe', shortLabel: 'Recipe', status: 'planning' },
+		{ label: 'Brew Day', shortLabel: 'Brew', status: 'brewing' },
+		{ label: 'Fermentation', shortLabel: 'Ferm', status: 'fermenting' },
+		{ label: 'Conditioning', shortLabel: 'Cond', status: 'conditioning' },
+		{ label: 'Complete', shortLabel: 'Done', status: 'completed' }
+	];
+
+	const statusOrder: Record<BatchStatus, number> = {
+		planning: 0,
+		brewing: 1,
+		fermenting: 2,
+		conditioning: 3,
+		completed: 4,
+		archived: 4
+	};
+
+	let currentIndex = $derived(statusOrder[currentStatus] ?? 0);
+
+	function phaseState(phaseIndex: number): 'completed' | 'current' | 'future' {
+		if (phaseIndex < currentIndex) return 'completed';
+		if (phaseIndex === currentIndex) return 'current';
+		return 'future';
+	}
+</script>
+
+<nav class="lifecycle-stepper" aria-label="Batch lifecycle progress">
+	<ol class="stepper-track">
+		{#each phases as phase, i}
+			{@const state = phaseState(i)}
+
+			{#if i > 0}
+				<li class="connector" class:filled={i <= currentIndex} aria-hidden="true"></li>
+			{/if}
+
+			<li
+				class="step"
+				class:completed={state === 'completed'}
+				class:current={state === 'current'}
+				class:future={state === 'future'}
+				aria-current={state === 'current' ? 'step' : undefined}
+			>
+				<div class="dot">
+					{#if state === 'completed'}
+						<svg
+							class="check-icon"
+							viewBox="0 0 16 16"
+							fill="none"
+							aria-hidden="true"
+						>
+							<path
+								d="M3.5 8.5L6.5 11.5L12.5 5.5"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							/>
+						</svg>
+					{/if}
+				</div>
+				<span class="label full-label">{phase.label}</span>
+				<span class="label short-label">{phase.shortLabel}</span>
+			</li>
+		{/each}
+	</ol>
+</nav>
+
+<style>
+	.lifecycle-stepper {
+		width: 100%;
+		padding: 0.5rem 0;
+	}
+
+	.stepper-track {
+		display: flex;
+		align-items: flex-start;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	/* --- Connector lines between dots --- */
+	.connector {
+		flex: 1;
+		height: 2px;
+		background: var(--border-subtle);
+		margin-top: 13px; /* vertically center with the 26px dot */
+		transition: background 0.3s ease;
+	}
+
+	.connector.filled {
+		background: var(--positive);
+	}
+
+	/* --- Step (dot + label) --- */
+	.step {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		flex-shrink: 0;
+	}
+
+	/* --- Dot --- */
+	.dot {
+		width: 26px;
+		height: 26px;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition: all 0.3s ease;
+		flex-shrink: 0;
+	}
+
+	.step.completed .dot {
+		background: var(--positive);
+		color: var(--bg-surface);
+	}
+
+	.step.current .dot {
+		background: var(--accent);
+		box-shadow: 0 0 0 4px var(--accent-muted);
+		animation: pulse-dot 2.5s ease-in-out infinite;
+	}
+
+	.step.future .dot {
+		background: var(--border-subtle);
+	}
+
+	.check-icon {
+		width: 14px;
+		height: 14px;
+	}
+
+	/* --- Label --- */
+	.label {
+		margin-top: 0.375rem;
+		font-size: 0.6875rem;
+		font-weight: 500;
+		text-align: center;
+		line-height: 1.2;
+		white-space: nowrap;
+		transition: color 0.3s ease;
+	}
+
+	.step.completed .label {
+		color: var(--positive);
+	}
+
+	.step.current .label {
+		color: var(--accent);
+		font-weight: 600;
+	}
+
+	.step.future .label {
+		color: var(--text-muted);
+	}
+
+	/* Show full labels by default, hide short ones */
+	.short-label {
+		display: none;
+	}
+
+	.full-label {
+		display: block;
+	}
+
+	/* On narrow screens, swap to abbreviated labels */
+	@media (max-width: 400px) {
+		.short-label {
+			display: block;
+		}
+		.full-label {
+			display: none;
+		}
+	}
+
+	/* --- Pulse animation for current dot --- */
+	@keyframes pulse-dot {
+		0%, 100% {
+			box-shadow: 0 0 0 4px var(--accent-muted);
+		}
+		50% {
+			box-shadow: 0 0 0 7px var(--accent-muted);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/batch/LifecycleStepper.svelte
+++ b/frontend/src/lib/components/batch/LifecycleStepper.svelte
@@ -3,9 +3,10 @@
 
 	interface Props {
 		currentStatus: BatchStatus;
+		onPhaseClick?: (status: BatchStatus) => void;
 	}
 
-	let { currentStatus }: Props = $props();
+	let { currentStatus, onPhaseClick }: Props = $props();
 
 	const phases: { label: string; shortLabel: string; status: BatchStatus }[] = [
 		{ label: 'Recipe', shortLabel: 'Recipe', status: 'planning' },
@@ -47,7 +48,12 @@
 				class:completed={state === 'completed'}
 				class:current={state === 'current'}
 				class:future={state === 'future'}
+				class:clickable={state !== 'future' && !!onPhaseClick}
 				aria-current={state === 'current' ? 'step' : undefined}
+				onclick={() => state !== 'future' && onPhaseClick?.(phase.status)}
+				onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && state !== 'future' && onPhaseClick?.(phase.status)}
+				role={onPhaseClick ? 'button' : undefined}
+				tabindex={state !== 'future' && onPhaseClick ? 0 : undefined}
 			>
 				<div class="dot">
 					{#if state === 'completed'}
@@ -107,6 +113,14 @@
 		flex-direction: column;
 		align-items: center;
 		flex-shrink: 0;
+	}
+
+	.step.clickable {
+		cursor: pointer;
+	}
+
+	.step.clickable:hover .dot {
+		transform: scale(1.15);
 	}
 
 	/* --- Dot --- */

--- a/frontend/src/lib/components/batch/PhaseBrewDay.svelte
+++ b/frontend/src/lib/components/batch/PhaseBrewDay.svelte
@@ -50,7 +50,18 @@
 </script>
 
 <div class="brewing-phase">
-	{#if isPrePitchChilling && !pitchTempReached}
+	{#if batch.status !== 'brewing' && batch.status !== 'planning'}
+		<!-- Historical: Brew day already completed -->
+		<div class="phase-action-card completed-brewday">
+			<div class="phase-icon">✅</div>
+			<h2 class="phase-title">Brew Day Complete</h2>
+			{#if batch.brewing_started_at || batch.brew_date}
+				<p class="phase-description">
+					Brewed on {new Date(batch.brewing_started_at || batch.brew_date || '').toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' })}
+				</p>
+			{/if}
+		</div>
+	{:else if isPrePitchChilling && !pitchTempReached}
 		<!-- Chilling in progress -->
 		<div class="phase-action-card chilling">
 			<div class="phase-icon">❄️</div>
@@ -195,6 +206,11 @@
 		flex-direction: column;
 		align-items: center;
 		gap: 1rem;
+	}
+
+	.phase-action-card.completed-brewday {
+		background: linear-gradient(135deg, rgba(34, 197, 94, 0.08) 0%, rgba(74, 222, 128, 0.03) 100%);
+		border-color: rgba(34, 197, 94, 0.25);
 	}
 
 	.phase-action-card.brewing {

--- a/frontend/src/lib/components/batch/PhaseBrewDay.svelte
+++ b/frontend/src/lib/components/batch/PhaseBrewDay.svelte
@@ -1,0 +1,371 @@
+<script lang="ts">
+	import type { BatchResponse } from '$lib/api';
+	import type { TiltReading } from '$lib/stores/tilts.svelte';
+	import { formatTemp, getTempUnit, configState } from '$lib/stores/config.svelte';
+	import BrewDayTimer from './BrewDayTimer.svelte';
+	import BrewDayChecklist from './BrewDayChecklist.svelte';
+	import BrewDayObservations from './BrewDayObservations.svelte';
+	import BatchDeviceCard from './BatchDeviceCard.svelte';
+	import BatchRecipeTargetsCard from './BatchRecipeTargetsCard.svelte';
+
+	interface Props {
+		batch: BatchResponse;
+		liveReading: TiltReading | null;
+		statusUpdating: boolean;
+		onStartFermentation: () => void;
+		onEdit: () => void;
+		onBatchUpdate: (updated: BatchResponse) => void;
+	}
+
+	let { batch, liveReading, statusUpdating, onStartFermentation, onEdit, onBatchUpdate }: Props = $props();
+
+	let tempUnit = $derived(getTempUnit());
+
+	let isPrePitchChilling = $derived(
+		(batch.status === 'planning' || batch.status === 'brewing') && batch.temp_target != null
+	);
+
+	let pitchTempReached = $derived.by(() => {
+		if (!isPrePitchChilling || !liveReading?.temp || !batch.temp_target) return false;
+		return liveReading.temp <= batch.temp_target;
+	});
+
+	let chillingProgress = $derived.by(() => {
+		if (!isPrePitchChilling || !liveReading?.temp || !batch.temp_target) return null;
+		const estimatedStartTemp = batch.temp_target + 30;
+		const currentTemp = liveReading.temp;
+		const targetTemp = batch.temp_target;
+
+		if (currentTemp <= targetTemp) return 100;
+		if (currentTemp >= estimatedStartTemp) return 0;
+
+		const progress = ((estimatedStartTemp - currentTemp) / (estimatedStartTemp - targetTemp)) * 100;
+		return Math.min(100, Math.max(0, progress));
+	});
+
+	function formatTempValue(value?: number | null): string {
+		if (value === undefined || value === null) return '--';
+		return formatTemp(value);
+	}
+</script>
+
+<div class="brewing-phase">
+	{#if isPrePitchChilling && !pitchTempReached}
+		<!-- Chilling in progress -->
+		<div class="phase-action-card chilling">
+			<div class="phase-icon">❄️</div>
+			<h2 class="phase-title">Chilling to Pitch Temperature</h2>
+			<p class="phase-description">
+				Wort is being cooled to pitch temperature. The cooler will run automatically.
+				Once target is reached, you can pitch the yeast.
+			</p>
+			<div class="chilling-temp-display">
+				<div class="temp-current">
+					<span class="temp-label">Current</span>
+					<span class="temp-value">{liveReading?.temp != null ? formatTempValue(liveReading.temp) : '--'}</span>
+				</div>
+				<div class="temp-arrow">→</div>
+				<div class="temp-target">
+					<span class="temp-label">Target</span>
+					<span class="temp-value">{batch.temp_target != null ? formatTempValue(batch.temp_target) : '--'}</span>
+				</div>
+			</div>
+			{#if chillingProgress != null}
+				<div class="chilling-progress">
+					<div class="progress-bar">
+						<div class="progress-fill" style="width: {chillingProgress}%"></div>
+					</div>
+					<span class="progress-text">{Math.round(chillingProgress)}% to pitch temp</span>
+				</div>
+			{/if}
+			<div class="chilling-status">
+				{#if !batch.cooler_entity_id}
+					<span class="status-warning">⚠️ No cooler configured - set in Edit to enable automated chilling</span>
+				{:else if !configState.config.ha_enabled || !configState.config.temp_control_enabled}
+					<span class="status-warning">⚠️ Temperature control disabled in settings</span>
+				{:else}
+					<span class="status-active">Cooler running automatically</span>
+				{/if}
+			</div>
+		</div>
+	{:else if isPrePitchChilling && pitchTempReached}
+		<!-- Ready to pitch -->
+		<div class="phase-action-card ready-to-pitch">
+			<div class="phase-icon">🍺</div>
+			<h2 class="phase-title">Ready to Pitch!</h2>
+			<p class="phase-description">
+				Wort has reached pitch temperature ({formatTempValue(batch.temp_target)}{tempUnit}).
+				Pitch the yeast and start fermentation.
+			</p>
+			<button
+				type="button"
+				class="start-fermentation-btn"
+				onclick={onStartFermentation}
+				disabled={statusUpdating}
+			>
+				{#if statusUpdating}
+					<span class="btn-spinner"></span>
+					Starting...
+				{:else}
+					<svg class="btn-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+					</svg>
+					Yeast Pitched - Start Fermentation
+				{/if}
+			</button>
+		</div>
+	{:else}
+		<!-- Normal brewing mode (no device/target set) -->
+		<div class="phase-action-card brewing">
+			<div class="phase-icon">🍺</div>
+			<h2 class="phase-title">Brew Day in Progress</h2>
+			<p class="phase-description">
+				Track your brew day activities. When you've pitched the yeast and fermentation begins, transition to the fermentation phase.
+			</p>
+			<button
+				type="button"
+				class="start-fermentation-btn"
+				onclick={onStartFermentation}
+				disabled={statusUpdating}
+			>
+				{#if statusUpdating}
+					<span class="btn-spinner"></span>
+					Starting...
+				{:else}
+					<svg class="btn-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+					</svg>
+					Yeast Pitched - Start Fermentation
+				{/if}
+			</button>
+		</div>
+	{/if}
+
+	<!-- Brew Day Tools Grid -->
+	<div class="brewday-tools-grid">
+		<!-- Timer -->
+		{#if batch.recipe}
+			<BrewDayTimer {batch} recipe={batch.recipe} />
+		{/if}
+
+		<!-- Checklist -->
+		{#if batch.recipe}
+			<BrewDayChecklist recipe={batch.recipe} batchId={batch.id} />
+		{/if}
+	</div>
+
+	<!-- Observations Log -->
+	{#if batch.recipe}
+		<BrewDayObservations
+			{batch}
+			recipe={batch.recipe}
+			onUpdate={(updated) => onBatchUpdate(updated)}
+		/>
+	{/if}
+
+	<!-- Device Card for chilling monitoring -->
+	{#if batch.device_id}
+		<BatchDeviceCard
+			{batch}
+			{liveReading}
+			onEdit={() => onEdit()}
+		/>
+	{/if}
+
+	{#if batch.recipe}
+		<BatchRecipeTargetsCard recipe={batch.recipe} yeastStrain={batch.yeast_strain} />
+	{/if}
+</div>
+
+<style>
+	.brewing-phase {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	/* Phase Action Card */
+	.phase-action-card {
+		background: linear-gradient(135deg, var(--bg-surface) 0%, var(--bg-elevated) 100%);
+		border: 1px solid var(--border-subtle);
+		border-radius: 1rem;
+		padding: 2rem;
+		text-align: center;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.phase-action-card.brewing {
+		background: linear-gradient(135deg, rgba(249, 115, 22, 0.08) 0%, rgba(251, 146, 60, 0.03) 100%);
+		border-color: rgba(249, 115, 22, 0.25);
+	}
+
+	.phase-action-card.chilling {
+		background: linear-gradient(135deg, rgba(59, 130, 246, 0.1) 0%, rgba(147, 197, 253, 0.05) 100%);
+		border-color: rgba(59, 130, 246, 0.3);
+	}
+
+	.phase-action-card.ready-to-pitch {
+		background: linear-gradient(135deg, rgba(34, 197, 94, 0.12) 0%, rgba(134, 239, 172, 0.05) 100%);
+		border-color: rgba(34, 197, 94, 0.35);
+	}
+
+	.chilling-temp-display {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 1.5rem;
+		margin: 0.5rem 0;
+	}
+
+	.chilling-temp-display .temp-current,
+	.chilling-temp-display .temp-target {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	.chilling-temp-display .temp-label {
+		font-size: 0.6875rem;
+		font-weight: 500;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.chilling-temp-display .temp-value {
+		font-size: 1.75rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.chilling-temp-display .temp-arrow {
+		font-size: 1.5rem;
+		color: var(--text-muted);
+	}
+
+	.chilling-progress {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		width: 100%;
+		max-width: 300px;
+	}
+
+	.chilling-progress .progress-bar {
+		width: 100%;
+		height: 8px;
+		background: var(--bg-elevated);
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	.chilling-progress .progress-fill {
+		height: 100%;
+		background: linear-gradient(90deg, var(--tilt-blue), var(--accent));
+		border-radius: 4px;
+		transition: width 0.5s ease;
+	}
+
+	.chilling-progress .progress-text {
+		font-size: 0.8125rem;
+		color: var(--text-secondary);
+	}
+
+	.phase-action-card .chilling-status {
+		margin-top: 0.5rem;
+		font-size: 0.8125rem;
+	}
+
+	.phase-action-card .status-warning {
+		color: var(--recipe-accent);
+	}
+
+	.phase-action-card .status-active {
+		color: var(--tilt-blue);
+	}
+
+	/* Brew Day Tools Grid */
+	.brewday-tools-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1rem;
+	}
+
+	@media (max-width: 900px) {
+		.brewday-tools-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.phase-icon {
+		font-size: 3rem;
+		line-height: 1;
+	}
+
+	.phase-title {
+		font-size: 1.5rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.phase-description {
+		font-size: 0.9375rem;
+		color: var(--text-secondary);
+		max-width: 400px;
+		line-height: 1.5;
+		margin: 0;
+	}
+
+	.start-fermentation-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		padding: 0.875rem 1.5rem;
+		font-size: 1rem;
+		font-weight: 600;
+		border-radius: 0.5rem;
+		cursor: pointer;
+		transition: all var(--transition);
+		margin-top: 0.5rem;
+		color: white;
+		background: linear-gradient(135deg, var(--status-fermenting) 0%, var(--recipe-accent) 100%);
+		border: none;
+	}
+
+	.start-fermentation-btn:hover:not(:disabled) {
+		filter: brightness(1.1);
+		transform: translateY(-1px);
+	}
+
+	.start-fermentation-btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+		transform: none;
+	}
+
+	.btn-spinner {
+		width: 1rem;
+		height: 1rem;
+		border: 2px solid rgba(255, 255, 255, 0.3);
+		border-top-color: white;
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+
+	.btn-icon {
+		width: 1rem;
+		height: 1rem;
+	}
+
+	@keyframes spin {
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/frontend/src/lib/components/batch/PhaseComplete.svelte
+++ b/frontend/src/lib/components/batch/PhaseComplete.svelte
@@ -1,0 +1,533 @@
+<script lang="ts">
+	import type { BatchResponse } from '$lib/api';
+	import type { BatchReflection } from '$lib/types/reflection';
+	import type { TastingNote } from '$lib/types/tasting';
+	import { formatGravity } from '$lib/stores/config.svelte';
+	import PackagingInfo from './PackagingInfo.svelte';
+	import TastingNotes from './TastingNotes.svelte';
+	import TastingNotesList from './TastingNotesList.svelte';
+	import ReflectionCard from './ReflectionCard.svelte';
+	import BatchNotesCard from './BatchNotesCard.svelte';
+
+	interface Props {
+		batch: BatchResponse;
+		reflections: BatchReflection[];
+		tastingNotes: TastingNote[];
+		reflectionsLoading: boolean;
+		tastingLoading: boolean;
+		onBatchUpdate: (updated: BatchResponse) => void;
+		onTastingNotesReload: () => void;
+	}
+
+	let {
+		batch,
+		reflections,
+		tastingNotes,
+		reflectionsLoading,
+		tastingLoading,
+		onBatchUpdate,
+		onTastingNotesReload,
+	}: Props = $props();
+
+	let reflectionsExpanded = $state(true);
+	let tastingExpanded = $state(true);
+
+	function formatSG(value?: number | null): string {
+		if (value === undefined || value === null) return '--';
+		return formatGravity(value);
+	}
+
+	function formatDate(dateStr?: string | null): string {
+		if (!dateStr) return '--';
+		return new Date(dateStr).toLocaleDateString('en-GB', {
+			weekday: 'short',
+			day: 'numeric',
+			month: 'short',
+			year: 'numeric'
+		});
+	}
+</script>
+
+<div class="completed-phase">
+	<div class="batch-summary-card">
+		<h2 class="summary-title">Batch Complete</h2>
+		<div class="summary-stats">
+			<div class="summary-stat">
+				<span class="stat-label">Original Gravity</span>
+				<span class="stat-value">{formatSG(batch.measured_og)}</span>
+			</div>
+			<div class="summary-stat">
+				<span class="stat-label">Final Gravity</span>
+				<span class="stat-value">{formatSG(batch.measured_fg)}</span>
+			</div>
+			<div class="summary-stat">
+				<span class="stat-label">ABV</span>
+				<span class="stat-value">{batch.measured_abv?.toFixed(1) ?? '--'}%</span>
+			</div>
+			<div class="summary-stat">
+				<span class="stat-label">Attenuation</span>
+				<span class="stat-value">
+					{#if batch.measured_og && batch.measured_fg}
+						{(((batch.measured_og - batch.measured_fg) / (batch.measured_og - 1)) * 100).toFixed(0)}%
+					{:else}
+						--
+					{/if}
+				</span>
+			</div>
+		</div>
+	</div>
+
+	<!-- Batch Timeline -->
+	<div class="timeline-card">
+		<h3 class="timeline-title">Batch Timeline</h3>
+		<div class="timeline">
+			{#if batch.brew_date || batch.brewing_started_at}
+				<div class="timeline-item">
+					<div class="timeline-dot brewing"></div>
+					<div class="timeline-content">
+						<span class="timeline-label">Brew Day</span>
+						<span class="timeline-date">{formatDate(batch.brewing_started_at || batch.brew_date)}</span>
+					</div>
+				</div>
+			{/if}
+			{#if batch.start_time || batch.fermenting_started_at}
+				<div class="timeline-item">
+					<div class="timeline-dot fermenting"></div>
+					<div class="timeline-content">
+						<span class="timeline-label">Fermentation Started</span>
+						<span class="timeline-date">{formatDate(batch.fermenting_started_at || batch.start_time)}</span>
+					</div>
+				</div>
+			{/if}
+			{#if batch.conditioning_started_at}
+				<div class="timeline-item">
+					<div class="timeline-dot conditioning"></div>
+					<div class="timeline-content">
+						<span class="timeline-label">Conditioning Started</span>
+						<span class="timeline-date">{formatDate(batch.conditioning_started_at)}</span>
+					</div>
+				</div>
+			{/if}
+			{#if batch.end_time || batch.completed_at}
+				<div class="timeline-item">
+					<div class="timeline-dot completed"></div>
+					<div class="timeline-content">
+						<span class="timeline-label">Completed</span>
+						<span class="timeline-date">{formatDate(batch.completed_at || batch.end_time)}</span>
+					</div>
+				</div>
+			{/if}
+			{#if batch.packaged_at}
+				<div class="timeline-item">
+					<div class="timeline-dot packaged"></div>
+					<div class="timeline-content">
+						<span class="timeline-label">Packaged ({batch.packaging_type || 'kegged'})</span>
+						<span class="timeline-date">{formatDate(batch.packaged_at)}</span>
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Packaging Info -->
+	<PackagingInfo
+		{batch}
+		onUpdate={(updated) => onBatchUpdate(updated)}
+	/>
+
+	<!-- Reflections & Learnings Section -->
+	<div class="postmortem-section">
+		<button
+			type="button"
+			class="section-header"
+			onclick={() => reflectionsExpanded = !reflectionsExpanded}
+		>
+			<div class="section-header-left">
+				<span class="section-icon">💭</span>
+				<h3 class="section-title">Reflections & Learnings</h3>
+				{#if reflections.length > 0}
+					<span class="section-count">{reflections.length}</span>
+				{/if}
+			</div>
+			<svg class="section-chevron" class:expanded={reflectionsExpanded} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+			</svg>
+		</button>
+
+		{#if reflectionsExpanded}
+			<div class="section-content">
+				{#if reflectionsLoading}
+					<div class="section-loading">
+						<div class="spinner-small"></div>
+						<span>Loading reflections...</span>
+					</div>
+				{:else if reflections.length === 0}
+					<div class="section-empty">
+						<p class="empty-text">No reflections recorded yet.</p>
+						<p class="empty-subtext">Reflections help you learn from each brew. Record what went well, what could improve, and lessons for next time.</p>
+						<button type="button" class="add-first-btn">
+							<svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+							</svg>
+							Add First Reflection
+						</button>
+					</div>
+				{:else}
+					<div class="reflections-grid">
+						{#each reflections as reflection}
+							<ReflectionCard {reflection} />
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Tasting Journal Section -->
+	<div class="postmortem-section">
+		<button
+			type="button"
+			class="section-header"
+			onclick={() => tastingExpanded = !tastingExpanded}
+		>
+			<div class="section-header-left">
+				<span class="section-icon">🍺</span>
+				<h3 class="section-title">Tasting Journal</h3>
+				{#if tastingNotes.length > 0}
+					<span class="section-count">{tastingNotes.length}</span>
+				{/if}
+			</div>
+			<svg class="section-chevron" class:expanded={tastingExpanded} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+			</svg>
+		</button>
+
+		{#if tastingExpanded}
+			<div class="section-content">
+				{#if tastingLoading}
+					<div class="section-loading">
+						<div class="spinner-small"></div>
+						<span>Loading tasting notes...</span>
+					</div>
+				{:else}
+					<TastingNotesList {tastingNotes} />
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Legacy Tasting Notes (for editing) -->
+	<TastingNotes
+		{batch}
+		onUpdate={(updated) => {
+			onBatchUpdate(updated);
+			onTastingNotesReload();
+		}}
+	/>
+
+	{#if batch.notes}
+		<BatchNotesCard notes={batch.notes} />
+	{/if}
+</div>
+
+<style>
+	.completed-phase {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	/* Completed Phase */
+	.batch-summary-card {
+		background: linear-gradient(135deg, rgba(34, 197, 94, 0.08) 0%, rgba(74, 222, 128, 0.03) 100%);
+		border: 1px solid rgba(34, 197, 94, 0.25);
+		border-radius: 1rem;
+		padding: 1.5rem;
+	}
+
+	.summary-title {
+		font-size: 1.25rem;
+		font-weight: 600;
+		color: var(--positive);
+		margin: 0 0 1.25rem 0;
+		text-align: center;
+	}
+
+	.summary-stats {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+		gap: 1rem;
+	}
+
+	.summary-stat {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.75rem;
+		background: var(--bg-surface);
+		border-radius: 0.5rem;
+	}
+
+	.stat-label {
+		font-size: 0.6875rem;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+	}
+
+	.stat-value {
+		font-size: 1.25rem;
+		font-weight: 600;
+		font-family: var(--font-mono);
+		color: var(--text-primary);
+	}
+
+	/* Timeline */
+	.timeline-card {
+		background: var(--bg-surface);
+		border: 1px solid var(--border-subtle);
+		border-radius: 0.75rem;
+		padding: 1.25rem;
+	}
+
+	.timeline-title {
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin: 0 0 1rem 0;
+	}
+
+	.timeline {
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+		position: relative;
+		padding-left: 1.5rem;
+	}
+
+	.timeline::before {
+		content: '';
+		position: absolute;
+		left: 0.4375rem;
+		top: 0.5rem;
+		bottom: 0.5rem;
+		width: 2px;
+		background: var(--border-subtle);
+	}
+
+	.timeline-item {
+		display: flex;
+		align-items: flex-start;
+		gap: 1rem;
+		padding: 0.75rem 0;
+		position: relative;
+	}
+
+	.timeline-dot {
+		position: absolute;
+		left: -1.5rem;
+		top: 1rem;
+		width: 0.875rem;
+		height: 0.875rem;
+		border-radius: 50%;
+		background: var(--bg-elevated);
+		border: 2px solid var(--border-default);
+		z-index: 1;
+	}
+
+	.timeline-dot.brewing {
+		background: var(--status-brewing, #f97316);
+		border-color: var(--status-brewing, #f97316);
+	}
+
+	.timeline-dot.fermenting {
+		background: var(--status-fermenting);
+		border-color: var(--status-fermenting);
+	}
+
+	.timeline-dot.conditioning {
+		background: var(--status-conditioning);
+		border-color: var(--status-conditioning);
+	}
+
+	.timeline-dot.completed {
+		background: var(--status-completed);
+		border-color: var(--status-completed);
+	}
+
+	.timeline-dot.packaged {
+		background: var(--amber);
+		border-color: var(--amber);
+	}
+
+	.timeline-content {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+	}
+
+	.timeline-label {
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--text-primary);
+	}
+
+	.timeline-date {
+		font-size: 0.8125rem;
+		color: var(--text-secondary);
+	}
+
+	/* Post-mortem Sections */
+	.postmortem-section {
+		background: var(--bg-surface);
+		border: 1px solid var(--border-subtle);
+		border-radius: 0.75rem;
+		overflow: hidden;
+	}
+
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		width: 100%;
+		padding: 1rem 1.25rem;
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		text-align: left;
+		transition: background 0.15s ease;
+	}
+
+	.section-header:hover {
+		background: var(--bg-elevated);
+	}
+
+	.section-header-left {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.section-icon {
+		font-size: 1.25rem;
+	}
+
+	.section-title {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.section-count {
+		font-size: 0.6875rem;
+		font-weight: 600;
+		padding: 0.125rem 0.5rem;
+		background: var(--accent-bg, rgba(99, 102, 241, 0.1));
+		color: var(--accent);
+		border-radius: 1rem;
+	}
+
+	.section-chevron {
+		width: 1.25rem;
+		height: 1.25rem;
+		color: var(--text-muted);
+		transition: transform 0.2s ease;
+	}
+
+	.section-chevron.expanded {
+		transform: rotate(180deg);
+	}
+
+	.section-content {
+		padding: 0 1.25rem 1.25rem;
+	}
+
+	.section-loading {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+		padding: 2rem;
+		color: var(--text-muted);
+		font-size: 0.875rem;
+	}
+
+	.spinner-small {
+		width: 1.25rem;
+		height: 1.25rem;
+		border: 2px solid var(--bg-hover);
+		border-top-color: var(--accent);
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+
+	.section-empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 2rem 1rem;
+		text-align: center;
+	}
+
+	.section-empty .empty-text {
+		font-size: 0.9375rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+		margin: 0 0 0.25rem 0;
+	}
+
+	.section-empty .empty-subtext {
+		font-size: 0.8125rem;
+		color: var(--text-muted);
+		margin: 0 0 1rem 0;
+		max-width: 320px;
+		line-height: 1.5;
+	}
+
+	.add-first-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.625rem 1rem;
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: var(--accent);
+		background: transparent;
+		border: 1px dashed var(--accent);
+		border-radius: 0.5rem;
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.add-first-btn:hover {
+		background: rgba(99, 102, 241, 0.1);
+	}
+
+	.add-first-btn svg {
+		width: 1rem;
+		height: 1rem;
+	}
+
+	.reflections-grid {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	@keyframes spin {
+		to { transform: rotate(360deg); }
+	}
+
+	@media (min-width: 768px) {
+		.reflections-grid {
+			display: grid;
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/batch/PhaseConditioning.svelte
+++ b/frontend/src/lib/components/batch/PhaseConditioning.svelte
@@ -1,0 +1,729 @@
+<script lang="ts">
+	import type { BatchResponse, BatchProgressResponse, BatchControlStatus, ControlEvent } from '$lib/api';
+	import type { TiltReading } from '$lib/stores/tilts.svelte';
+	import type { TastingNote } from '$lib/types/tasting';
+	import { formatTemp, getTempUnit, configState } from '$lib/stores/config.svelte';
+	import BatchFermentationCard from './BatchFermentationCard.svelte';
+	import BatchRecipeTargetsCard from './BatchRecipeTargetsCard.svelte';
+	import MLPredictions from './MLPredictions.svelte';
+	import BatchNotesCard from './BatchNotesCard.svelte';
+	import TastingNotesList from './TastingNotesList.svelte';
+	import FermentationChart from '../FermentationChart.svelte';
+
+	interface Props {
+		batch: BatchResponse;
+		progress: BatchProgressResponse | null;
+		liveReading: TiltReading | null;
+		controlStatus: BatchControlStatus | null;
+		controlEvents: ControlEvent[];
+		hasTempControl: boolean;
+		heaterLoading: boolean;
+		tempControlCollapsed: boolean;
+		tastingNotes: TastingNote[];
+		tastingLoading: boolean;
+		onOverride: (deviceType: 'heater' | 'cooler', state: 'on' | 'off' | null) => void;
+		onClearOverrides: () => void;
+		onTempControlToggle: () => void;
+	}
+
+	let {
+		batch,
+		progress,
+		liveReading,
+		controlStatus,
+		controlEvents,
+		hasTempControl,
+		heaterLoading,
+		tempControlCollapsed,
+		tastingNotes,
+		tastingLoading,
+		onOverride,
+		onClearOverrides,
+		onTempControlToggle,
+	}: Props = $props();
+
+	let tempUnit = $derived(getTempUnit());
+
+	function formatTempValue(value?: number | null): string {
+		if (value === undefined || value === null) return '--';
+		return formatTemp(value);
+	}
+</script>
+
+<div class="content-grid">
+	<!-- Left column -->
+	<div class="stats-section">
+		<!-- Fermentation Card (includes live readings) -->
+		<BatchFermentationCard
+			{batch}
+			currentSg={liveReading?.sg ?? progress?.measured?.current_sg}
+			{progress}
+			{liveReading}
+		/>
+
+		<!-- Recipe Targets Card (only if recipe exists) -->
+		{#if batch.recipe}
+			<BatchRecipeTargetsCard recipe={batch.recipe} yeastStrain={batch.yeast_strain} />
+		{/if}
+
+		<!-- Tasting Journal - Primary activity during conditioning -->
+		<div class="tasting-card">
+			<h3 class="card-title">
+				<span class="card-icon">🍺</span>
+				Tasting Journal
+				{#if tastingNotes.length > 0}
+					<span class="note-count">{tastingNotes.length}</span>
+				{/if}
+			</h3>
+			{#if tastingLoading}
+				<div class="loading-state">
+					<div class="spinner-small"></div>
+					<span>Loading tasting notes...</span>
+				</div>
+			{:else if tastingNotes.length === 0}
+				<div class="empty-state">
+					<p class="empty-text">No tasting notes yet.</p>
+					<p class="empty-subtext">Track how your beer develops during conditioning. Regular tasting notes help you learn and decide when it's ready.</p>
+				</div>
+			{:else}
+				<TastingNotesList {tastingNotes} />
+			{/if}
+		</div>
+	</div>
+
+	<!-- Right column -->
+	<div class="info-section">
+		<!-- ML Predictions Panel -->
+		<MLPredictions
+			batchId={batch.id}
+			batchStatus={batch.status}
+			measuredOg={batch.measured_og}
+			measuredFg={batch.measured_fg ?? progress?.measured?.current_sg}
+			recipeFg={batch.recipe?.fg}
+			currentSg={liveReading?.sg ?? progress?.measured?.current_sg}
+			{liveReading}
+		/>
+
+		<!-- Temperature Control Card -->
+		{#if hasTempControl}
+			<div class="info-card temp-control-card"
+				class:heater-on={controlStatus?.heater_state === 'on'}
+				class:cooler-on={controlStatus?.cooler_state === 'on'}
+				class:collapsed={tempControlCollapsed}>
+				<button
+					type="button"
+					class="collapsible-header"
+					onclick={onTempControlToggle}
+				>
+					<h3 class="info-title">Temperature Control</h3>
+					<div class="collapse-indicator">
+						{#if controlStatus?.heater_state === 'on'}
+							<span class="status-badge heater">🔥 Heating</span>
+						{:else if controlStatus?.cooler_state === 'on'}
+							<span class="status-badge cooler">❄️ Cooling</span>
+						{:else if tempControlCollapsed && controlStatus}
+							<span class="status-badge idle">🎯 {formatTempValue(controlStatus.target_temp)}{tempUnit}</span>
+						{/if}
+						<svg class="chevron" class:rotated={!tempControlCollapsed} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+						</svg>
+					</div>
+				</button>
+
+				{#if !tempControlCollapsed}
+				<!-- Device status indicators -->
+				<div class="device-status-grid">
+					{#if batch.heater_entity_id}
+						<div class="device-status heater">
+							<div class="device-icon-wrap" class:active={controlStatus?.heater_state === 'on'}>
+								🔥
+							</div>
+							<div class="device-info">
+								<span class="device-label">Heater</span>
+								<span class="device-state" class:on={controlStatus?.heater_state === 'on'}>
+									{controlStatus?.heater_state === 'on' ? 'ON' : 'OFF'}
+								</span>
+								<span class="device-entity">{batch.heater_entity_id}</span>
+							</div>
+						</div>
+					{/if}
+
+					{#if batch.cooler_entity_id}
+						<div class="device-status cooler">
+							<div class="device-icon-wrap" class:active={controlStatus?.cooler_state === 'on'}>
+								❄️
+							</div>
+							<div class="device-info">
+								<span class="device-label">Cooler</span>
+								<span class="device-state" class:on={controlStatus?.cooler_state === 'on'}>
+									{controlStatus?.cooler_state === 'on' ? 'ON' : 'OFF'}
+								</span>
+								<span class="device-entity">{batch.cooler_entity_id}</span>
+							</div>
+						</div>
+					{/if}
+				</div>
+
+				{#if controlStatus}
+					<div class="control-details">
+						<div class="control-detail">
+							<span class="detail-label">Target</span>
+							<span class="detail-value">{formatTempValue(controlStatus.target_temp)}{tempUnit}</span>
+						</div>
+						<div class="control-detail">
+							<span class="detail-label">Hysteresis</span>
+							<span class="detail-value">±{controlStatus.hysteresis?.toFixed(1) || '--'}{tempUnit}</span>
+						</div>
+					</div>
+
+					{#if controlStatus.override_active}
+						<div class="override-banner">
+							<span class="override-icon">⚡</span>
+							<span>Override active: {controlStatus.override_state?.toUpperCase()}</span>
+							<button
+								type="button"
+								class="override-cancel-inline"
+								onclick={() => onClearOverrides()}
+								disabled={heaterLoading}
+							>
+								Cancel
+							</button>
+						</div>
+					{/if}
+
+					<div class="override-controls">
+						<span class="override-label">Manual Override (1hr)</span>
+						<div class="override-btns-grid">
+							{#if batch.heater_entity_id}
+								<button
+									type="button"
+									class="override-btn heat-on"
+									onclick={() => onOverride('heater', 'on')}
+									disabled={heaterLoading}
+								>
+									Force Heat ON
+								</button>
+								<button
+									type="button"
+									class="override-btn heat-off"
+									onclick={() => onOverride('heater', 'off')}
+									disabled={heaterLoading}
+								>
+									Force Heat OFF
+								</button>
+							{/if}
+
+							{#if batch.cooler_entity_id}
+								<button
+									type="button"
+									class="override-btn cool-on"
+									onclick={() => onOverride('cooler', 'on')}
+									disabled={heaterLoading}
+								>
+									Force Cool ON
+								</button>
+								<button
+									type="button"
+									class="override-btn cool-off"
+									onclick={() => onOverride('cooler', 'off')}
+									disabled={heaterLoading}
+								>
+									Force Cool OFF
+								</button>
+							{/if}
+
+							<button
+								type="button"
+								class="override-btn auto-mode"
+								onclick={() => onClearOverrides()}
+								disabled={heaterLoading}
+							>
+								Auto Mode
+							</button>
+						</div>
+					</div>
+				{/if}
+				{/if}
+			</div>
+		{:else if batch.heater_entity_id || batch.cooler_entity_id}
+			<div class="info-card">
+				<h3 class="info-title">Temperature Control</h3>
+				<div class="no-device">
+					{#if batch.heater_entity_id}
+						<span>Heater: {batch.heater_entity_id}</span>
+					{/if}
+					{#if batch.cooler_entity_id}
+						<span>Cooler: {batch.cooler_entity_id}</span>
+					{/if}
+					<span class="hint">Active only during fermentation</span>
+				</div>
+			</div>
+		{/if}
+
+		<!-- Notes Card (only if notes exist) -->
+		{#if batch.notes}
+			<BatchNotesCard notes={batch.notes} />
+		{/if}
+	</div>
+</div>
+
+<!-- Fermentation Chart (shows historical data for all batches with a device) -->
+{#if batch.device_id}
+	<div class="chart-section">
+		<FermentationChart
+			batchId={batch.id}
+			deviceColor={batch.device_id}
+			originalGravity={batch.measured_og}
+			{controlEvents}
+		/>
+	</div>
+{/if}
+
+<style>
+	/* Content grid - two column layout */
+	.content-grid {
+		display: grid;
+		grid-template-columns: 2fr 1fr;
+		gap: 1rem;
+		align-items: start;
+	}
+
+	@media (max-width: 900px) {
+		.content-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	/* Chart section */
+	.chart-section {
+		margin-top: 1.5rem;
+	}
+
+	/* Stats section (left column) */
+	.stats-section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	/* Info section (right column) */
+	.info-section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.info-card {
+		background: var(--bg-surface);
+		border: 1px solid var(--border-subtle);
+		border-radius: 0.75rem;
+		padding: 1.25rem;
+	}
+
+	.info-title {
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin: 0 0 1rem 0;
+	}
+
+	.no-device {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		font-size: 0.875rem;
+		color: var(--text-muted);
+	}
+
+	.hint {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+
+	/* Tasting Journal Card */
+	.tasting-card {
+		background: var(--bg-surface);
+		border: 1px solid var(--border-subtle);
+		border-radius: 0.75rem;
+		padding: 1.25rem;
+	}
+
+	.card-title {
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin: 0 0 1rem 0;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.card-icon { font-size: 1rem; }
+
+	.note-count {
+		font-size: 0.6875rem;
+		font-weight: 600;
+		padding: 0.125rem 0.5rem;
+		background: var(--accent-bg, rgba(99, 102, 241, 0.1));
+		color: var(--accent);
+		border-radius: 1rem;
+	}
+
+	.loading-state {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+		padding: 2rem;
+		color: var(--text-muted);
+		font-size: 0.875rem;
+	}
+
+	.spinner-small {
+		width: 1.25rem;
+		height: 1.25rem;
+		border: 2px solid var(--bg-hover);
+		border-top-color: var(--accent);
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+
+	.empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 2rem 1rem;
+		text-align: center;
+	}
+
+	.empty-text {
+		font-size: 0.9375rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+		margin: 0 0 0.25rem 0;
+	}
+
+	.empty-subtext {
+		font-size: 0.8125rem;
+		color: var(--text-muted);
+		margin: 0;
+		max-width: 320px;
+		line-height: 1.5;
+	}
+
+	/* Temperature Control Card */
+	.temp-control-card {
+		transition: all 0.3s ease;
+	}
+
+	.temp-control-card.collapsed {
+		padding-bottom: 0.75rem;
+	}
+
+	.collapsible-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		width: 100%;
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0;
+		margin-bottom: 1rem;
+	}
+
+	.temp-control-card.collapsed .collapsible-header {
+		margin-bottom: 0;
+	}
+
+	.collapsible-header .info-title {
+		margin: 0;
+	}
+
+	.collapse-indicator {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.status-badge {
+		font-size: 0.6875rem;
+		font-weight: 600;
+		padding: 0.125rem 0.375rem;
+		border-radius: 0.25rem;
+	}
+
+	.status-badge.heater {
+		background: rgba(239, 68, 68, 0.15);
+		color: var(--tilt-red);
+	}
+
+	.status-badge.cooler {
+		background: rgba(59, 130, 246, 0.15);
+		color: var(--tilt-blue);
+	}
+
+	.status-badge.idle {
+		background: var(--bg-elevated);
+		color: var(--text-secondary);
+	}
+
+	.chevron {
+		width: 1rem;
+		height: 1rem;
+		color: var(--text-muted);
+		transition: transform 0.2s ease;
+	}
+
+	.chevron.rotated {
+		transform: rotate(180deg);
+	}
+
+	.temp-control-card.heater-on {
+		background: rgba(239, 68, 68, 0.08);
+		border-color: rgba(239, 68, 68, 0.3);
+	}
+
+	.temp-control-card.cooler-on {
+		background: rgba(59, 130, 246, 0.08);
+		border-color: rgba(59, 130, 246, 0.3);
+	}
+
+	.device-status-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+		gap: 0.75rem;
+		margin-bottom: 1rem;
+	}
+
+	.device-status {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.device-icon-wrap {
+		width: 2.5rem;
+		height: 2.5rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 0.5rem;
+		background: var(--bg-elevated);
+		font-size: 1.25rem;
+		transition: all 0.3s ease;
+		filter: grayscale(100%) opacity(0.5);
+	}
+
+	.device-status.heater .device-icon-wrap.active {
+		background: rgba(239, 68, 68, 0.2);
+		animation: pulse-glow-red 2s ease-in-out infinite;
+		filter: none;
+	}
+
+	.device-status.cooler .device-icon-wrap.active {
+		background: rgba(59, 130, 246, 0.2);
+		animation: pulse-glow-blue 2s ease-in-out infinite;
+		filter: none;
+	}
+
+	@keyframes pulse-glow-red {
+		0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4); }
+		50% { box-shadow: 0 0 15px 3px rgba(239, 68, 68, 0.3); }
+	}
+
+	@keyframes pulse-glow-blue {
+		0%, 100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4); }
+		50% { box-shadow: 0 0 15px 3px rgba(59, 130, 246, 0.3); }
+	}
+
+	.device-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+	}
+
+	.device-label {
+		font-size: 0.625rem;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+	}
+
+	.device-state {
+		font-size: 1rem;
+		font-weight: 700;
+		font-family: 'JetBrains Mono', monospace;
+		color: var(--text-secondary);
+	}
+
+	.device-status.heater .device-state.on {
+		color: var(--tilt-red);
+	}
+
+	.device-status.cooler .device-state.on {
+		color: var(--tilt-blue);
+	}
+
+	.device-entity {
+		font-size: 0.6875rem;
+		color: var(--text-muted);
+		font-family: 'JetBrains Mono', monospace;
+	}
+
+	.control-details {
+		display: flex;
+		gap: 1.5rem;
+		margin-bottom: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		background: var(--bg-elevated);
+		border-radius: 0.375rem;
+	}
+
+	.control-detail {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+	}
+
+	.detail-label {
+		font-size: 0.625rem;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+	}
+
+	.detail-value {
+		font-size: 0.875rem;
+		font-weight: 500;
+		font-family: 'JetBrains Mono', monospace;
+		color: var(--text-primary);
+	}
+
+	.override-banner {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		background: rgba(59, 130, 246, 0.1);
+		border-radius: 0.375rem;
+		font-size: 0.75rem;
+		color: var(--tilt-blue);
+	}
+
+	.override-icon {
+		font-size: 0.875rem;
+	}
+
+	.override-cancel-inline {
+		margin-left: auto;
+		padding: 0.25rem 0.5rem;
+		font-size: 0.6875rem;
+		font-weight: 500;
+		border-radius: 0.25rem;
+		background: transparent;
+		border: 1px solid var(--tilt-blue);
+		color: var(--tilt-blue);
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.override-cancel-inline:hover:not(:disabled) {
+		background: rgba(59, 130, 246, 0.15);
+	}
+
+	.override-cancel-inline:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.override-controls {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+	}
+
+	.override-label {
+		font-size: 0.625rem;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+	}
+
+	.override-btns-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 0.375rem;
+	}
+
+	.override-btn {
+		padding: 0.5rem 0.75rem;
+		font-size: 0.6875rem;
+		font-weight: 500;
+		border-radius: 0.25rem;
+		background: var(--bg-elevated);
+		border: 1px solid var(--border-subtle);
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.override-btn:hover:not(:disabled) {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.override-btn.heat-on:hover:not(:disabled) {
+		background: rgba(239, 68, 68, 0.1);
+		border-color: var(--tilt-red);
+		color: var(--tilt-red);
+	}
+
+	.override-btn.heat-off:hover:not(:disabled) {
+		background: rgba(239, 68, 68, 0.05);
+		border-color: rgba(239, 68, 68, 0.3);
+		color: var(--text-primary);
+	}
+
+	.override-btn.cool-on:hover:not(:disabled) {
+		background: rgba(59, 130, 246, 0.1);
+		border-color: var(--tilt-blue);
+		color: var(--tilt-blue);
+	}
+
+	.override-btn.cool-off:hover:not(:disabled) {
+		background: rgba(59, 130, 246, 0.05);
+		border-color: rgba(59, 130, 246, 0.3);
+		color: var(--text-primary);
+	}
+
+	.override-btn.auto-mode {
+		grid-column: 1 / -1;
+		background: var(--accent);
+		border-color: var(--accent);
+		color: white;
+	}
+
+	.override-btn.auto-mode:hover:not(:disabled) {
+		background: var(--accent-hover);
+		border-color: var(--accent-hover);
+	}
+
+	.override-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	@keyframes spin {
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/frontend/src/lib/components/batch/PhaseConditioning.svelte
+++ b/frontend/src/lib/components/batch/PhaseConditioning.svelte
@@ -6,9 +6,9 @@
 	import BatchFermentationCard from './BatchFermentationCard.svelte';
 	import BatchRecipeTargetsCard from './BatchRecipeTargetsCard.svelte';
 	import BatchAlertsCard from './BatchAlertsCard.svelte';
-	import MLPredictions from './MLPredictions.svelte';
 	import BatchNotesCard from './BatchNotesCard.svelte';
 	import TastingNotesList from './TastingNotesList.svelte';
+	import TastingNotes from './TastingNotes.svelte';
 	import FermentationChart from '../FermentationChart.svelte';
 
 	interface Props {
@@ -25,6 +25,8 @@
 		onOverride: (deviceType: 'heater' | 'cooler', state: 'on' | 'off' | null) => void;
 		onClearOverrides: () => void;
 		onTempControlToggle: () => void;
+		onBatchUpdate: (updated: BatchResponse) => void;
+		onTastingNotesReload: () => void;
 	}
 
 	let {
@@ -41,6 +43,8 @@
 		onOverride,
 		onClearOverrides,
 		onTempControlToggle,
+		onBatchUpdate,
+		onTastingNotesReload,
 	}: Props = $props();
 
 	let tempUnit = $derived(getTempUnit());
@@ -90,23 +94,21 @@
 				<TastingNotesList {tastingNotes} />
 			{/if}
 		</div>
+
+		<!-- Tasting Notes CRUD Form -->
+		<TastingNotes
+			{batch}
+			onUpdate={(updated) => {
+				onBatchUpdate(updated);
+				onTastingNotesReload();
+			}}
+		/>
 	</div>
 
 	<!-- Right column -->
 	<div class="info-section">
 		<!-- Active Alerts Card -->
 		<BatchAlertsCard batchId={batch.id} />
-
-		<!-- ML Predictions Panel -->
-		<MLPredictions
-			batchId={batch.id}
-			batchStatus={batch.status}
-			measuredOg={batch.measured_og}
-			measuredFg={batch.measured_fg ?? progress?.measured?.current_sg}
-			recipeFg={batch.recipe?.fg}
-			currentSg={liveReading?.sg ?? progress?.measured?.current_sg}
-			{liveReading}
-		/>
 
 		<!-- Temperature Control Card -->
 		{#if hasTempControl}

--- a/frontend/src/lib/components/batch/PhaseConditioning.svelte
+++ b/frontend/src/lib/components/batch/PhaseConditioning.svelte
@@ -5,6 +5,7 @@
 	import { formatTemp, getTempUnit, configState } from '$lib/stores/config.svelte';
 	import BatchFermentationCard from './BatchFermentationCard.svelte';
 	import BatchRecipeTargetsCard from './BatchRecipeTargetsCard.svelte';
+	import BatchAlertsCard from './BatchAlertsCard.svelte';
 	import MLPredictions from './MLPredictions.svelte';
 	import BatchNotesCard from './BatchNotesCard.svelte';
 	import TastingNotesList from './TastingNotesList.svelte';
@@ -93,6 +94,9 @@
 
 	<!-- Right column -->
 	<div class="info-section">
+		<!-- Active Alerts Card -->
+		<BatchAlertsCard batchId={batch.id} />
+
 		<!-- ML Predictions Panel -->
 		<MLPredictions
 			batchId={batch.id}

--- a/frontend/src/lib/components/batch/PhaseFermentation.svelte
+++ b/frontend/src/lib/components/batch/PhaseFermentation.svelte
@@ -1,0 +1,628 @@
+<script lang="ts">
+	import type { BatchResponse, BatchProgressResponse, BatchControlStatus, ControlEvent } from '$lib/api';
+	import type { TiltReading } from '$lib/stores/tilts.svelte';
+	import { formatTemp, getTempUnit, configState } from '$lib/stores/config.svelte';
+	import BatchFermentationCard from './BatchFermentationCard.svelte';
+	import BatchRecipeTargetsCard from './BatchRecipeTargetsCard.svelte';
+	import BatchAlertsCard from './BatchAlertsCard.svelte';
+	import MLPredictions from './MLPredictions.svelte';
+	import BatchNotesCard from './BatchNotesCard.svelte';
+	import FermentationChart from '../FermentationChart.svelte';
+
+	interface Props {
+		batch: BatchResponse;
+		progress: BatchProgressResponse | null;
+		liveReading: TiltReading | null;
+		controlStatus: BatchControlStatus | null;
+		controlEvents: ControlEvent[];
+		hasTempControl: boolean;
+		heaterLoading: boolean;
+		tempControlCollapsed: boolean;
+		onOverride: (deviceType: 'heater' | 'cooler', state: 'on' | 'off' | null) => void;
+		onClearOverrides: () => void;
+		onTempControlToggle: () => void;
+	}
+
+	let {
+		batch,
+		progress,
+		liveReading,
+		controlStatus,
+		controlEvents,
+		hasTempControl,
+		heaterLoading,
+		tempControlCollapsed,
+		onOverride,
+		onClearOverrides,
+		onTempControlToggle,
+	}: Props = $props();
+
+	let tempUnit = $derived(getTempUnit());
+
+	function formatTempValue(value?: number | null): string {
+		if (value === undefined || value === null) return '--';
+		return formatTemp(value);
+	}
+</script>
+
+<div class="content-grid">
+	<!-- Left column -->
+	<div class="stats-section">
+		<!-- Fermentation Card (includes live readings) -->
+		<BatchFermentationCard
+			{batch}
+			currentSg={liveReading?.sg ?? progress?.measured?.current_sg}
+			{progress}
+			{liveReading}
+		/>
+
+		<!-- Recipe Targets Card (only if recipe exists) -->
+		{#if batch.recipe}
+			<BatchRecipeTargetsCard recipe={batch.recipe} yeastStrain={batch.yeast_strain} />
+		{/if}
+	</div>
+
+	<!-- Right column -->
+	<div class="info-section">
+		<!-- Active Alerts Card (only show during fermentation/conditioning) -->
+		{#if batch.status === 'fermenting' || batch.status === 'conditioning'}
+			<BatchAlertsCard batchId={batch.id} />
+		{/if}
+
+		<!-- ML Predictions Panel -->
+		<MLPredictions
+			batchId={batch.id}
+			batchStatus={batch.status}
+			measuredOg={batch.measured_og}
+			measuredFg={batch.measured_fg ?? progress?.measured?.current_sg}
+			recipeFg={batch.recipe?.fg}
+			currentSg={liveReading?.sg ?? progress?.measured?.current_sg}
+			{liveReading}
+		/>
+
+		<!-- Temperature Control Card -->
+		{#if hasTempControl && (batch.status === 'fermenting' || batch.status === 'conditioning')}
+			<div class="info-card temp-control-card"
+				class:heater-on={controlStatus?.heater_state === 'on'}
+				class:cooler-on={controlStatus?.cooler_state === 'on'}
+				class:collapsed={tempControlCollapsed}>
+				<button
+					type="button"
+					class="collapsible-header"
+					onclick={onTempControlToggle}
+				>
+					<h3 class="info-title">Temperature Control</h3>
+					<div class="collapse-indicator">
+						{#if controlStatus?.heater_state === 'on'}
+							<span class="status-badge heater">🔥 Heating</span>
+						{:else if controlStatus?.cooler_state === 'on'}
+							<span class="status-badge cooler">❄️ Cooling</span>
+						{:else if tempControlCollapsed && controlStatus}
+							<span class="status-badge idle">🎯 {formatTempValue(controlStatus.target_temp)}{tempUnit}</span>
+						{/if}
+						<svg class="chevron" class:rotated={!tempControlCollapsed} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+						</svg>
+					</div>
+				</button>
+
+				{#if !tempControlCollapsed}
+				<!-- Device status indicators -->
+				<div class="device-status-grid">
+					{#if batch.heater_entity_id}
+						<div class="device-status heater">
+							<div class="device-icon-wrap" class:active={controlStatus?.heater_state === 'on'}>
+								🔥
+							</div>
+							<div class="device-info">
+								<span class="device-label">Heater</span>
+								<span class="device-state" class:on={controlStatus?.heater_state === 'on'}>
+									{controlStatus?.heater_state === 'on' ? 'ON' : 'OFF'}
+								</span>
+								<span class="device-entity">{batch.heater_entity_id}</span>
+							</div>
+						</div>
+					{/if}
+
+					{#if batch.cooler_entity_id}
+						<div class="device-status cooler">
+							<div class="device-icon-wrap" class:active={controlStatus?.cooler_state === 'on'}>
+								❄️
+							</div>
+							<div class="device-info">
+								<span class="device-label">Cooler</span>
+								<span class="device-state" class:on={controlStatus?.cooler_state === 'on'}>
+									{controlStatus?.cooler_state === 'on' ? 'ON' : 'OFF'}
+								</span>
+								<span class="device-entity">{batch.cooler_entity_id}</span>
+							</div>
+						</div>
+					{/if}
+				</div>
+
+				{#if controlStatus}
+					<div class="control-details">
+						<div class="control-detail">
+							<span class="detail-label">Target</span>
+							<span class="detail-value">{formatTempValue(controlStatus.target_temp)}{tempUnit}</span>
+						</div>
+						<div class="control-detail">
+							<span class="detail-label">Hysteresis</span>
+							<span class="detail-value">±{controlStatus.hysteresis?.toFixed(1) || '--'}{tempUnit}</span>
+						</div>
+					</div>
+
+					{#if controlStatus.override_active}
+						<div class="override-banner">
+							<span class="override-icon">⚡</span>
+							<span>Override active: {controlStatus.override_state?.toUpperCase()}</span>
+							<button
+								type="button"
+								class="override-cancel-inline"
+								onclick={() => onClearOverrides()}
+								disabled={heaterLoading}
+							>
+								Cancel
+							</button>
+						</div>
+					{/if}
+
+					<div class="override-controls">
+						<span class="override-label">Manual Override (1hr)</span>
+						<div class="override-btns-grid">
+							{#if batch.heater_entity_id}
+								<button
+									type="button"
+									class="override-btn heat-on"
+									onclick={() => onOverride('heater', 'on')}
+									disabled={heaterLoading}
+								>
+									Force Heat ON
+								</button>
+								<button
+									type="button"
+									class="override-btn heat-off"
+									onclick={() => onOverride('heater', 'off')}
+									disabled={heaterLoading}
+								>
+									Force Heat OFF
+								</button>
+							{/if}
+
+							{#if batch.cooler_entity_id}
+								<button
+									type="button"
+									class="override-btn cool-on"
+									onclick={() => onOverride('cooler', 'on')}
+									disabled={heaterLoading}
+								>
+									Force Cool ON
+								</button>
+								<button
+									type="button"
+									class="override-btn cool-off"
+									onclick={() => onOverride('cooler', 'off')}
+									disabled={heaterLoading}
+								>
+									Force Cool OFF
+								</button>
+							{/if}
+
+							<button
+								type="button"
+								class="override-btn auto-mode"
+								onclick={() => onClearOverrides()}
+								disabled={heaterLoading}
+							>
+								Auto Mode
+							</button>
+						</div>
+					</div>
+				{/if}
+				{/if}
+			</div>
+		{:else if (batch.heater_entity_id || batch.cooler_entity_id) && batch.status !== 'fermenting'}
+			<div class="info-card">
+				<h3 class="info-title">Temperature Control</h3>
+				<div class="no-device">
+					{#if batch.heater_entity_id}
+						<span>Heater: {batch.heater_entity_id}</span>
+					{/if}
+					{#if batch.cooler_entity_id}
+						<span>Cooler: {batch.cooler_entity_id}</span>
+					{/if}
+					<span class="hint">Active only during fermentation</span>
+				</div>
+			</div>
+		{/if}
+
+		<!-- Notes Card (only if notes exist) -->
+		{#if batch.notes}
+			<BatchNotesCard notes={batch.notes} />
+		{/if}
+	</div>
+</div>
+
+<!-- Fermentation Chart (shows historical data for all batches with a device) -->
+{#if batch.device_id}
+	<div class="chart-section">
+		<FermentationChart
+			batchId={batch.id}
+			deviceColor={batch.device_id}
+			originalGravity={batch.measured_og}
+			{controlEvents}
+		/>
+	</div>
+{/if}
+
+<style>
+	/* Content grid */
+	.content-grid {
+		display: grid;
+		grid-template-columns: 2fr 1fr;
+		gap: 1rem;
+		align-items: start;
+	}
+
+	@media (max-width: 900px) {
+		.content-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	/* Stats section */
+	.stats-section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	/* Info section */
+	.info-section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.info-card {
+		background: var(--bg-surface);
+		border: 1px solid var(--border-subtle);
+		border-radius: 0.75rem;
+		padding: 1.25rem;
+	}
+
+	.info-title {
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin: 0 0 1rem 0;
+	}
+
+	/* Chart section */
+	.chart-section {
+		margin-top: 1.5rem;
+	}
+
+	/* Keep .no-device for heater card compatibility */
+	.no-device {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		font-size: 0.875rem;
+		color: var(--text-muted);
+	}
+
+	.hint {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+
+	/* Temperature Control Card */
+	.temp-control-card {
+		transition: all 0.3s ease;
+	}
+
+	.temp-control-card.collapsed {
+		padding-bottom: 0.75rem;
+	}
+
+	.collapsible-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		width: 100%;
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0;
+		margin-bottom: 1rem;
+	}
+
+	.temp-control-card.collapsed .collapsible-header {
+		margin-bottom: 0;
+	}
+
+	.collapsible-header .info-title {
+		margin: 0;
+	}
+
+	.collapse-indicator {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.status-badge {
+		font-size: 0.6875rem;
+		font-weight: 600;
+		padding: 0.125rem 0.375rem;
+		border-radius: 0.25rem;
+	}
+
+	.status-badge.heater {
+		background: rgba(239, 68, 68, 0.15);
+		color: var(--tilt-red);
+	}
+
+	.status-badge.cooler {
+		background: rgba(59, 130, 246, 0.15);
+		color: var(--tilt-blue);
+	}
+
+	.status-badge.idle {
+		background: var(--bg-elevated);
+		color: var(--text-secondary);
+	}
+
+	.chevron {
+		width: 1rem;
+		height: 1rem;
+		color: var(--text-muted);
+		transition: transform 0.2s ease;
+	}
+
+	.chevron.rotated {
+		transform: rotate(180deg);
+	}
+
+	.temp-control-card.heater-on {
+		background: rgba(239, 68, 68, 0.08);
+		border-color: rgba(239, 68, 68, 0.3);
+	}
+
+	.temp-control-card.cooler-on {
+		background: rgba(59, 130, 246, 0.08);
+		border-color: rgba(59, 130, 246, 0.3);
+	}
+
+	.device-status-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+		gap: 0.75rem;
+		margin-bottom: 1rem;
+	}
+
+	.device-status {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.device-icon-wrap {
+		width: 2.5rem;
+		height: 2.5rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 0.5rem;
+		background: var(--bg-elevated);
+		font-size: 1.25rem;
+		transition: all 0.3s ease;
+		filter: grayscale(100%) opacity(0.5);
+	}
+
+	.device-status.heater .device-icon-wrap.active {
+		background: rgba(239, 68, 68, 0.2);
+		animation: pulse-glow-red 2s ease-in-out infinite;
+		filter: none;
+	}
+
+	.device-status.cooler .device-icon-wrap.active {
+		background: rgba(59, 130, 246, 0.2);
+		animation: pulse-glow-blue 2s ease-in-out infinite;
+		filter: none;
+	}
+
+	@keyframes pulse-glow-red {
+		0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4); }
+		50% { box-shadow: 0 0 15px 3px rgba(239, 68, 68, 0.3); }
+	}
+
+	@keyframes pulse-glow-blue {
+		0%, 100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4); }
+		50% { box-shadow: 0 0 15px 3px rgba(59, 130, 246, 0.3); }
+	}
+
+	.device-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+	}
+
+	.device-label {
+		font-size: 0.625rem;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+	}
+
+	.device-state {
+		font-size: 1rem;
+		font-weight: 700;
+		font-family: 'JetBrains Mono', monospace;
+		color: var(--text-secondary);
+	}
+
+	.device-status.heater .device-state.on {
+		color: var(--tilt-red);
+	}
+
+	.device-status.cooler .device-state.on {
+		color: var(--tilt-blue);
+	}
+
+	.device-entity {
+		font-size: 0.6875rem;
+		color: var(--text-muted);
+		font-family: 'JetBrains Mono', monospace;
+	}
+
+	.control-details {
+		display: flex;
+		gap: 1.5rem;
+		margin-bottom: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		background: var(--bg-elevated);
+		border-radius: 0.375rem;
+	}
+
+	.control-detail {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+	}
+
+	.detail-label {
+		font-size: 0.625rem;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+	}
+
+	.detail-value {
+		font-size: 0.875rem;
+		font-weight: 500;
+		font-family: 'JetBrains Mono', monospace;
+		color: var(--text-primary);
+	}
+
+	.override-banner {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		background: rgba(59, 130, 246, 0.1);
+		border-radius: 0.375rem;
+		font-size: 0.75rem;
+		color: var(--tilt-blue);
+	}
+
+	.override-icon {
+		font-size: 0.875rem;
+	}
+
+	.override-cancel-inline {
+		margin-left: auto;
+		padding: 0.25rem 0.5rem;
+		font-size: 0.6875rem;
+		font-weight: 500;
+		border-radius: 0.25rem;
+		background: transparent;
+		border: 1px solid var(--tilt-blue);
+		color: var(--tilt-blue);
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.override-cancel-inline:hover:not(:disabled) {
+		background: rgba(59, 130, 246, 0.15);
+	}
+
+	.override-cancel-inline:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.override-controls {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+	}
+
+	.override-label {
+		font-size: 0.625rem;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+	}
+
+	.override-btns-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 0.375rem;
+	}
+
+	.override-btn {
+		padding: 0.5rem 0.75rem;
+		font-size: 0.6875rem;
+		font-weight: 500;
+		border-radius: 0.25rem;
+		background: var(--bg-elevated);
+		border: 1px solid var(--border-subtle);
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.override-btn:hover:not(:disabled) {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.override-btn.heat-on:hover:not(:disabled) {
+		background: rgba(239, 68, 68, 0.1);
+		border-color: var(--tilt-red);
+		color: var(--tilt-red);
+	}
+
+	.override-btn.heat-off:hover:not(:disabled) {
+		background: rgba(239, 68, 68, 0.05);
+		border-color: rgba(239, 68, 68, 0.3);
+		color: var(--text-primary);
+	}
+
+	.override-btn.cool-on:hover:not(:disabled) {
+		background: rgba(59, 130, 246, 0.1);
+		border-color: var(--tilt-blue);
+		color: var(--tilt-blue);
+	}
+
+	.override-btn.cool-off:hover:not(:disabled) {
+		background: rgba(59, 130, 246, 0.05);
+		border-color: rgba(59, 130, 246, 0.3);
+		color: var(--text-primary);
+	}
+
+	.override-btn.auto-mode {
+		grid-column: 1 / -1;
+		background: var(--accent);
+		border-color: var(--accent);
+		color: white;
+	}
+
+	.override-btn.auto-mode:hover:not(:disabled) {
+		background: var(--accent-hover);
+		border-color: var(--accent-hover);
+	}
+
+	.override-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>

--- a/frontend/src/lib/components/batch/PhaseRecipe.svelte
+++ b/frontend/src/lib/components/batch/PhaseRecipe.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	import type { BatchResponse } from '$lib/api';
+	import BatchRecipeTargetsCard from './BatchRecipeTargetsCard.svelte';
+
+	interface Props {
+		batch: BatchResponse;
+		statusUpdating: boolean;
+		onStartBrewDay: () => void;
+	}
+
+	let { batch, statusUpdating, onStartBrewDay }: Props = $props();
+</script>
+
+<div class="planning-phase">
+	<div class="phase-action-card">
+		<div class="phase-icon">📋</div>
+		<h2 class="phase-title">Ready to Brew?</h2>
+		<p class="phase-description">
+			Review your recipe below, then start brew day when you're ready to begin.
+		</p>
+		<button
+			type="button"
+			class="start-brewday-btn"
+			onclick={onStartBrewDay}
+			disabled={statusUpdating}
+		>
+			{#if statusUpdating}
+				<span class="btn-spinner"></span>
+				Starting...
+			{:else}
+				<svg class="btn-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+					<path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+				</svg>
+				Start Brew Day
+			{/if}
+		</button>
+	</div>
+
+	{#if batch.recipe}
+		<BatchRecipeTargetsCard recipe={batch.recipe} yeastStrain={batch.yeast_strain} />
+	{/if}
+</div>
+
+<style>
+	.planning-phase {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.phase-action-card {
+		background: linear-gradient(135deg, var(--bg-surface) 0%, var(--bg-elevated) 100%);
+		border: 1px solid var(--border-subtle);
+		border-radius: 1rem;
+		padding: 2rem;
+		text-align: center;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.phase-icon {
+		font-size: 3rem;
+		line-height: 1;
+	}
+
+	.phase-title {
+		font-size: 1.5rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.phase-description {
+		font-size: 0.9375rem;
+		color: var(--text-secondary);
+		max-width: 400px;
+		line-height: 1.5;
+		margin: 0;
+	}
+
+	.start-brewday-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		padding: 0.875rem 1.5rem;
+		font-size: 1rem;
+		font-weight: 600;
+		border-radius: 0.5rem;
+		cursor: pointer;
+		transition: all var(--transition);
+		margin-top: 0.5rem;
+		color: white;
+		background: var(--accent);
+		border: none;
+	}
+
+	.start-brewday-btn:hover:not(:disabled) {
+		background: var(--accent-hover);
+		transform: translateY(-1px);
+	}
+
+	.start-brewday-btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+		transform: none;
+	}
+
+	.btn-spinner {
+		width: 1rem;
+		height: 1rem;
+		border: 2px solid rgba(255, 255, 255, 0.3);
+		border-top-color: white;
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+
+	.btn-icon {
+		width: 1rem;
+		height: 1rem;
+	}
+
+	@keyframes spin {
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/frontend/src/lib/components/batch/PhaseRecipe.svelte
+++ b/frontend/src/lib/components/batch/PhaseRecipe.svelte
@@ -12,30 +12,46 @@
 </script>
 
 <div class="planning-phase">
-	<div class="phase-action-card">
-		<div class="phase-icon">📋</div>
-		<h2 class="phase-title">Ready to Brew?</h2>
-		<p class="phase-description">
-			Review your recipe below, then start brew day when you're ready to begin.
-		</p>
-		<button
-			type="button"
-			class="start-brewday-btn"
-			onclick={onStartBrewDay}
-			disabled={statusUpdating}
-		>
-			{#if statusUpdating}
-				<span class="btn-spinner"></span>
-				Starting...
-			{:else}
-				<svg class="btn-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
-					<path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-				</svg>
-				Start Brew Day
-			{/if}
-		</button>
-	</div>
+	{#if batch.status === 'planning'}
+		<!-- Active: show Start Brew Day action -->
+		<div class="phase-action-card">
+			<div class="phase-icon">📋</div>
+			<h2 class="phase-title">Ready to Brew?</h2>
+			<p class="phase-description">
+				Review your recipe below, then start brew day when you're ready to begin.
+			</p>
+			<button
+				type="button"
+				class="start-brewday-btn"
+				onclick={onStartBrewDay}
+				disabled={statusUpdating}
+			>
+				{#if statusUpdating}
+					<span class="btn-spinner"></span>
+					Starting...
+				{:else}
+					<svg class="btn-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+						<path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+					</svg>
+					Start Brew Day
+				{/if}
+			</button>
+		</div>
+	{:else}
+		<!-- Historical: show recipe link -->
+		{#if batch.recipe}
+			<div class="recipe-summary-card">
+				<h2 class="recipe-name">{batch.recipe.name}</h2>
+				{#if batch.recipe.style?.name}
+					<p class="recipe-style">{batch.recipe.style.name}</p>
+				{/if}
+				<a href="/recipes/{batch.recipe.id}" class="view-recipe-link">
+					View Full Recipe →
+				</a>
+			</div>
+		{/if}
+	{/if}
 
 	{#if batch.recipe}
 		<BatchRecipeTargetsCard recipe={batch.recipe} yeastStrain={batch.yeast_strain} />
@@ -121,6 +137,48 @@
 	.btn-icon {
 		width: 1rem;
 		height: 1rem;
+	}
+
+	.recipe-summary-card {
+		background: var(--bg-surface);
+		border: 1px solid var(--border-subtle);
+		border-radius: 1rem;
+		padding: 2rem;
+		text-align: center;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.recipe-name {
+		font-size: 1.25rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.recipe-style {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	.view-recipe-link {
+		display: inline-block;
+		margin-top: 0.5rem;
+		padding: 0.5rem 1rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--accent);
+		text-decoration: none;
+		border: 1px solid var(--accent);
+		border-radius: 0.375rem;
+		transition: all 0.15s ease;
+	}
+
+	.view-recipe-link:hover {
+		background: rgba(99, 102, 241, 0.1);
 	}
 
 	@keyframes spin {

--- a/frontend/src/routes/batches/[id]/+page.svelte
+++ b/frontend/src/routes/batches/[id]/+page.svelte
@@ -613,6 +613,8 @@
 					onOverride={handleOverride}
 					onClearOverrides={handleClearAllOverrides}
 					onTempControlToggle={() => tempControlCollapsed = !tempControlCollapsed}
+					onBatchUpdate={(updated) => batch = updated}
+					onTastingNotesReload={loadTastingNotes}
 				/>
 			{:else if activeTab === 'completed'}
 				<PhaseComplete


### PR DESCRIPTION
## Summary
- Extract monolithic 2,583-line batch detail page into 6 phase-specific components with tab navigation
- Add LifecycleStepper horizontal progress indicator with clickable completed phases
- Tab bar switches between Recipe, Brew Day, Fermentation, Conditioning, and Complete phases
- Future tabs show dimmed styling and "Not started yet" placeholder
- Page reduced from ~2,583 to ~1,074 lines

## New Components
| Component | Purpose |
|-----------|---------|
| `LifecycleStepper` | Horizontal progress stepper with checkmarks, pulsing current dot |
| `PhaseRecipe` | Planning view with "Start Brew Day" action + recipe targets |
| `PhaseBrewDay` | Brew day tools, chilling monitor, observations, pitch temp tracking |
| `PhaseFermentation` | 2-column: fermentation card + ML predictions + temp control + chart |
| `PhaseConditioning` | Same as fermentation + prominent tasting journal (not collapsible) |
| `PhaseComplete` | Batch summary, timeline, packaging, reflections, tasting journal |

## Phase 1 of 4
This is the extraction/architecture phase. Future phases:
- Phase 2: Conditioning differentiation (cold crash progress, phase-specific stats)
- Phase 3: Recipe-driven guidance (fermentation schedule from recipe data)
- Phase 4: Transition prompts (ML-detected completion prompts)

## Test plan
- [ ] Verify each tab renders correctly for batches in each status
- [ ] Verify future tabs show "Not started yet" placeholder
- [ ] Verify clicking stepper dots switches active tab
- [ ] Verify status transitions (Start Brew Day, Start Fermentation) still work
- [ ] Verify temp control, ML predictions, and chart render on fermentation/conditioning tabs
- [ ] Verify tasting journal is prominent on conditioning tab
- [ ] Verify reflections and packaging info on complete tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)