### PR TITLE
feat(recipe): AI Review on view page + fix modal close-on-drag bug

### DIFF
--- a/frontend/src/lib/components/recipe/RecipeBuilder.svelte
+++ b/frontend/src/lib/components/recipe/RecipeBuilder.svelte
@@ -61,8 +61,8 @@
 
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { marked } from 'marked';
 	import { fetchYeastStrains, reviewRecipe, searchStyles, type RecipeReviewResponse, type BJCPStyleResponse } from '$lib/api';
+	import RecipeReviewModal from './RecipeReviewModal.svelte';
 	import FermentableSelector from './FermentableSelector.svelte';
 	import HopSelector from './HopSelector.svelte';
 	import YeastSelector from '$lib/components/batch/YeastSelector.svelte';
@@ -980,42 +980,14 @@
 {/if}
 
 <!-- AI Review Modal -->
-{#if showReviewModal}
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div class="modal-overlay" onclick={closeReviewModal} onkeydown={(e) => e.key === 'Escape' && closeReviewModal()} role="presentation">
-		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="review-modal-title" tabindex="-1" onkeydown={(e) => e.stopPropagation()}>
-			<div class="modal-header">
-				<h2 id="review-modal-title">AI Recipe Review</h2>
-				<button class="modal-close" onclick={closeReviewModal} aria-label="Close">&times;</button>
-			</div>
-			<div class="modal-body">
-				{#if reviewLoading}
-					<div class="review-loading">
-						<div class="spinner"></div>
-						<p>Analyzing your recipe against {styleInput || 'style guidelines'}...</p>
-					</div>
-				{:else if reviewError}
-					<div class="review-error">
-						<p>{reviewError}</p>
-					</div>
-				{:else if reviewResult}
-					<div class="review-meta">
-						{#if reviewResult.style_found}
-							<span class="style-badge found">BJCP Style: {reviewResult.style_name}</span>
-						{:else}
-							<span class="style-badge not-found">Style not in BJCP database</span>
-						{/if}
-						<span class="model-badge">Model: {reviewResult.model}</span>
-					</div>
-					<div class="review-content markdown-body">
-						{@html marked(reviewResult.review)}
-					</div>
-				{/if}
-			</div>
-		</div>
-	</div>
-{/if}
+<RecipeReviewModal
+	open={showReviewModal}
+	loading={reviewLoading}
+	error={reviewError}
+	result={reviewResult}
+	styleName={styleInput}
+	onClose={closeReviewModal}
+/>
 
 <style>
 	.recipe-builder {
@@ -1864,125 +1836,6 @@
 		overflow-y: auto;
 	}
 
-	.review-loading {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: var(--space-4);
-		padding: var(--space-8) 0;
-	}
-
-	.spinner {
-		width: 40px;
-		height: 40px;
-		border: 3px solid var(--border-default);
-		border-top-color: var(--positive);
-		border-radius: 50%;
-		animation: spin 1s linear infinite;
-	}
-
-	@keyframes spin {
-		to {
-			transform: rotate(360deg);
-		}
-	}
-
-	.review-loading p {
-		color: var(--text-secondary);
-		margin: 0;
-	}
-
-	.review-error {
-		padding: var(--space-4);
-		background: var(--negative-bg);
-		border: 1px solid var(--negative);
-		border-radius: 8px;
-		color: var(--negative);
-	}
-
-	.review-meta {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--space-2);
-		margin-bottom: var(--space-4);
-	}
-
-	.style-badge,
-	.model-badge {
-		display: inline-block;
-		padding: var(--space-1) var(--space-3);
-		border-radius: 20px;
-		font-size: 12px;
-		font-weight: 500;
-	}
-
-	.style-badge.found {
-		background: var(--positive-bg);
-		color: var(--positive);
-		border: 1px solid var(--positive);
-	}
-
-	.style-badge.not-found {
-		background: var(--warning-bg);
-		color: var(--warning);
-		border: 1px solid var(--warning);
-	}
-
-	.model-badge {
-		background: var(--bg-elevated);
-		color: var(--text-secondary);
-		border: 1px solid var(--border-default);
-	}
-
-	.review-content {
-		line-height: 1.7;
-		color: var(--text-primary);
-	}
-
-	.review-content :global(h3) {
-		margin-top: var(--space-5);
-		margin-bottom: var(--space-2);
-		font-size: 16px;
-		font-weight: 600;
-		color: var(--text-primary);
-	}
-
-	.review-content :global(h3:first-child) {
-		margin-top: 0;
-	}
-
-	.review-content :global(ul) {
-		margin: var(--space-2) 0;
-		padding-left: var(--space-5);
-	}
-
-	.review-content :global(li) {
-		margin-bottom: var(--space-2);
-	}
-
-	.review-content :global(p) {
-		margin: var(--space-3) 0;
-	}
-
-	.review-content :global(p:first-child) {
-		margin-top: 0;
-	}
-
-	.review-content :global(strong) {
-		font-weight: 600;
-		color: var(--text-primary);
-	}
-
-	.review-content :global(em) {
-		font-style: italic;
-	}
-
-	.review-content :global(hr) {
-		border: none;
-		border-top: 1px solid var(--border-subtle);
-		margin: var(--space-4) 0;
-	}
-
 	/* Style Autocomplete */
 	.style-autocomplete {
 		position: relative;
@@ -2008,6 +1861,12 @@
 		border-top-color: var(--accent-primary);
 		border-radius: 50%;
 		animation: spin 0.8s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
 	}
 
 	.clear-style {

--- a/frontend/src/lib/components/recipe/RecipeReviewModal.svelte
+++ b/frontend/src/lib/components/recipe/RecipeReviewModal.svelte
@@ -1,0 +1,298 @@
+<script lang="ts">
+	import { marked } from 'marked';
+	import type { RecipeReviewResponse } from '$lib/api';
+
+	interface Props {
+		open: boolean;
+		loading: boolean;
+		error: string | null;
+		result: RecipeReviewResponse | null;
+		styleName?: string;
+		onClose: () => void;
+	}
+
+	let { open, loading, error, result, styleName = '', onClose }: Props = $props();
+
+	// Track where a pointer interaction began. Only treat the overlay as
+	// "clicked outside" when both mousedown AND mouseup land on the
+	// overlay itself — otherwise dragging a text selection that ends on
+	// the overlay would unexpectedly close the modal mid-highlight.
+	let pointerDownOnOverlay = $state(false);
+
+	function handleOverlayPointerDown(e: PointerEvent) {
+		pointerDownOnOverlay = e.target === e.currentTarget;
+	}
+
+	function handleOverlayClick(e: MouseEvent) {
+		if (pointerDownOnOverlay && e.target === e.currentTarget) {
+			onClose();
+		}
+		pointerDownOnOverlay = false;
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') onClose();
+	}
+</script>
+
+{#if open}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="modal-overlay"
+		onpointerdown={handleOverlayPointerDown}
+		onclick={handleOverlayClick}
+		onkeydown={handleKeydown}
+		role="presentation"
+	>
+		<div
+			class="modal-content"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="review-modal-title"
+			tabindex="-1"
+			onkeydown={(e) => e.stopPropagation()}
+		>
+			<div class="modal-header">
+				<h2 id="review-modal-title">AI Recipe Review</h2>
+				<button class="modal-close" onclick={onClose} aria-label="Close">&times;</button>
+			</div>
+			<div class="modal-body">
+				{#if loading}
+					<div class="review-loading">
+						<div class="spinner"></div>
+						<p>Analyzing your recipe against {styleName || 'style guidelines'}...</p>
+					</div>
+				{:else if error}
+					<div class="review-error">
+						<p>{error}</p>
+					</div>
+				{:else if result}
+					<div class="review-meta">
+						{#if result.style_found}
+							<span class="style-badge found">BJCP Style: {result.style_name}</span>
+						{:else}
+							<span class="style-badge not-found">Style not in BJCP database</span>
+						{/if}
+						<span class="model-badge">Model: {result.model}</span>
+					</div>
+					<div class="review-content markdown-body">
+						{@html marked(result.review)}
+					</div>
+				{/if}
+			</div>
+			<div class="modal-footer">
+				<button type="button" class="btn-close" onclick={onClose}>Close</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.modal-overlay {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background: rgba(0, 0, 0, 0.7);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+		padding: var(--space-4);
+	}
+
+	.modal-content {
+		background: var(--bg-surface);
+		border: 1px solid var(--border-default);
+		border-radius: 12px;
+		max-width: 700px;
+		width: 100%;
+		max-height: 80vh;
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+		box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-4) var(--space-5);
+		border-bottom: 1px solid var(--border-subtle);
+	}
+
+	.modal-header h2 {
+		margin: 0;
+		font-size: 18px;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.modal-close {
+		background: none;
+		border: none;
+		font-size: 24px;
+		color: var(--text-secondary);
+		cursor: pointer;
+		padding: 0;
+		line-height: 1;
+	}
+
+	.modal-close:hover {
+		color: var(--text-primary);
+	}
+
+	.modal-body {
+		padding: var(--space-5);
+		overflow-y: auto;
+	}
+
+	.modal-footer {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--space-2);
+		padding: var(--space-3) var(--space-5);
+		border-top: 1px solid var(--border-subtle);
+	}
+
+	.btn-close {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: 8px 16px;
+		font-size: 13px;
+		font-weight: 500;
+		background: transparent;
+		border: 1px solid var(--border-default);
+		border-radius: 8px;
+		color: var(--text-primary);
+		cursor: pointer;
+		transition: all 0.2s ease;
+	}
+
+	.btn-close:hover {
+		background: var(--bg-hover);
+		border-color: var(--text-secondary);
+	}
+
+	.review-loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--space-4);
+		padding: var(--space-8) 0;
+	}
+
+	.spinner {
+		width: 40px;
+		height: 40px;
+		border: 3px solid var(--border-default);
+		border-top-color: var(--positive);
+		border-radius: 50%;
+		animation: spin 1s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.review-loading p {
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	.review-error {
+		padding: var(--space-4);
+		background: var(--negative-bg);
+		border: 1px solid var(--negative);
+		border-radius: 8px;
+		color: var(--negative);
+	}
+
+	.review-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-2);
+		margin-bottom: var(--space-4);
+	}
+
+	.style-badge,
+	.model-badge {
+		display: inline-block;
+		padding: var(--space-1) var(--space-3);
+		border-radius: 20px;
+		font-size: 12px;
+		font-weight: 500;
+	}
+
+	.style-badge.found {
+		background: var(--positive-bg);
+		color: var(--positive);
+		border: 1px solid var(--positive);
+	}
+
+	.style-badge.not-found {
+		background: var(--warning-bg);
+		color: var(--warning);
+		border: 1px solid var(--warning);
+	}
+
+	.model-badge {
+		background: var(--bg-elevated);
+		color: var(--text-secondary);
+		border: 1px solid var(--border-default);
+	}
+
+	.review-content {
+		line-height: 1.7;
+		color: var(--text-primary);
+	}
+
+	.review-content :global(h3) {
+		margin-top: var(--space-5);
+		margin-bottom: var(--space-2);
+		font-size: 16px;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.review-content :global(h3:first-child) {
+		margin-top: 0;
+	}
+
+	.review-content :global(ul) {
+		margin: var(--space-2) 0;
+		padding-left: var(--space-5);
+	}
+
+	.review-content :global(li) {
+		margin-bottom: var(--space-2);
+	}
+
+	.review-content :global(p) {
+		margin: var(--space-3) 0;
+	}
+
+	.review-content :global(p:first-child) {
+		margin-top: 0;
+	}
+
+	.review-content :global(strong) {
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.review-content :global(em) {
+		font-style: italic;
+	}
+
+	.review-content :global(hr) {
+		border: none;
+		border-top: 1px solid var(--border-subtle);
+		margin: var(--space-4) 0;
+	}
+</style>

--- a/frontend/src/routes/recipes/[id]/+page.svelte
+++ b/frontend/src/routes/recipes/[id]/+page.svelte
@@ -2,14 +2,15 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
-	import type { RecipeResponse } from '$lib/api';
-	import { fetchRecipe, deleteRecipe } from '$lib/api';
+	import type { RecipeResponse, RecipeReviewResponse } from '$lib/api';
+	import { fetchRecipe, deleteRecipe, reviewRecipe } from '$lib/api';
 	import FermentablesList from '$lib/components/recipe/FermentablesList.svelte';
 	import HopSchedule from '$lib/components/recipe/HopSchedule.svelte';
 	import MashSchedule from '$lib/components/recipe/MashSchedule.svelte';
 	import FermentationSchedule from '$lib/components/recipe/FermentationSchedule.svelte';
 	import WaterAdditions from '$lib/components/recipe/WaterAdditions.svelte';
 	import RecipeStatsPanel from '$lib/components/recipe/RecipeStatsPanel.svelte';
+	import RecipeReviewModal from '$lib/components/recipe/RecipeReviewModal.svelte';
 	import { normalizeHopUse } from '$lib/components/recipe/RecipeBuilder.svelte';
 	import { calculateWaterVolumes } from '$lib/utils/water';
 	import { calculateRecipeStats, type Fermentable, type Hop, type Yeast, type BatchParams } from '$lib/brewing';
@@ -19,6 +20,12 @@
 	let error = $state<string | null>(null);
 	let showDeleteConfirm = $state(false);
 	let deleting = $state(false);
+
+	// AI Review state
+	let showReviewModal = $state(false);
+	let reviewResult = $state<RecipeReviewResponse | null>(null);
+	let reviewLoading = $state(false);
+	let reviewError = $state<string | null>(null);
 
 	let waterVolumes = $derived.by(() => {
 		if (!recipe?.batch_size_liters || !recipe.fermentables?.length) return null;
@@ -153,6 +160,90 @@
 		if (!recipe) return;
 		goto(`/batches/new?recipe_id=${recipe.id}`);
 	}
+
+	async function handleReview() {
+		if (!recipe) return;
+
+		if (!recipe.type?.trim()) {
+			reviewError = 'Recipe is missing a beer style — edit the recipe and add one to get an AI review';
+			showReviewModal = true;
+			return;
+		}
+
+		const fermentables = recipe.fermentables ?? [];
+		if (fermentables.length === 0) {
+			reviewError = 'Recipe has no fermentables to review';
+			showReviewModal = true;
+			return;
+		}
+
+		reviewLoading = true;
+		reviewError = null;
+		reviewResult = null;
+		showReviewModal = true;
+
+		try {
+			const stats = liveStats;
+			// Prefer brewer-declared imported targets when present (they
+			// reflect what the brewer wrote); otherwise fall back to live
+			// calculator output, then stored stats.
+			const og = recipe.target_og ?? stats?.og ?? recipe.og ?? 1.05;
+			const fg = recipe.target_fg ?? stats?.fg ?? recipe.fg ?? 1.01;
+			const abv = recipe.target_abv ?? stats?.abv ?? recipe.abv ?? 5.0;
+			const ibu = recipe.target_ibu ?? stats?.ibu ?? recipe.ibu ?? 30;
+			const colorSrm = recipe.target_srm ?? stats?.srm ?? recipe.color_srm ?? 8;
+
+			reviewResult = await reviewRecipe({
+				name: recipe.name || 'Untitled Recipe',
+				style: recipe.type,
+				og,
+				fg,
+				abv,
+				ibu,
+				color_srm: colorSrm,
+				fermentables: fermentables.map((f) => ({
+					name: f.name,
+					amount_kg: f.amount_kg ?? 0,
+					color_srm: f.color_srm,
+					type: f.type
+				})),
+				hops: (recipe.hops ?? []).map((h) => {
+					const timing = h.timing || {};
+					const tv = timing.duration?.value ?? timing.time?.value ?? 0;
+					const tu = timing.duration?.unit ?? timing.time?.unit ?? 'min';
+					const minutes = tu === 'day' ? tv * 24 * 60 : tv;
+					const use = normalizeHopUse(timing.use);
+					return {
+						name: h.name,
+						amount_grams: h.amount_grams ?? 0,
+						// Don't expose dry-hop / mash duration as IBU-time
+						// to the LLM — the review prompt would misread a
+						// 4-day dry hop as an absurd boil duration.
+						boil_time_minutes: use === 'dry_hop' || use === 'mash' ? 0 : minutes,
+						alpha_acid_percent: h.alpha_acid_percent,
+						use
+					};
+				}),
+				yeast: recipe.yeast_name
+					? {
+							name: recipe.yeast_name,
+							producer: recipe.yeast_lab ?? undefined,
+							attenuation: recipe.yeast_attenuation ?? undefined
+						}
+					: undefined
+			});
+		} catch (err) {
+			reviewError = err instanceof Error ? err.message : 'Failed to get AI review';
+		} finally {
+			reviewLoading = false;
+		}
+	}
+
+	function closeReviewModal() {
+		showReviewModal = false;
+		reviewResult = null;
+		reviewError = null;
+	}
 </script>
 
 <svelte:head>
@@ -194,6 +285,22 @@
 					</div>
 				</div>
 				<div class="header-actions">
+					<button
+						type="button"
+						class="btn-review"
+						onclick={handleReview}
+						disabled={reviewLoading}
+					>
+						{#if reviewLoading}
+							<span class="btn-spinner"></span>
+							Analyzing...
+						{:else}
+							<svg class="btn-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+								<path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" />
+							</svg>
+							AI Review
+						{/if}
+					</button>
 					<a href="/recipes/{recipe.id}/edit" class="btn-secondary">
 						<svg class="btn-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 							<path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -401,6 +508,16 @@
 	{/if}
 </div>
 
+<!-- AI Review Modal -->
+<RecipeReviewModal
+	open={showReviewModal}
+	loading={reviewLoading}
+	error={reviewError}
+	result={reviewResult}
+	styleName={recipe?.type ?? ''}
+	onClose={closeReviewModal}
+/>
+
 <!-- Delete Confirmation Modal -->
 {#if showDeleteConfirm}
 	<div
@@ -604,6 +721,30 @@
 		border-color: var(--recipe-accent);
 		color: var(--recipe-accent);
 		background: rgba(245, 158, 11, 0.05);
+	}
+
+	.btn-review {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: 9px 16px;
+		font-size: 13px;
+		font-weight: 500;
+		background: rgba(34, 197, 94, 0.08);
+		border: 1px solid var(--positive, #22c55e);
+		border-radius: 8px;
+		color: var(--positive, #22c55e);
+		cursor: pointer;
+		transition: all 0.2s ease;
+	}
+
+	.btn-review:hover:not(:disabled) {
+		background: rgba(34, 197, 94, 0.15);
+	}
+
+	.btn-review:disabled {
+		opacity: 0.6;
+		cursor: wait;
 	}
 
 	.btn-primary {


### PR DESCRIPTION
## Summary
- Add AI Review button + modal to recipe view page (previously only on edit page)
- Extract `RecipeReviewModal` into reusable component
- Fix modal closing mid-text-selection when drag-highlight ends on overlay

## Modal close UX fix
Tracks `pointerdown` target — overlay click only closes when both pointerdown AND click land on the overlay. Highlighting text inside the modal and releasing on the dimmed background no longer dismisses it. Added explicit Close button in footer; existing × icon and Escape still work.

## Test plan
- [x] Deployed to Pi (192.168.4.218), service active
- [x] Playwright: AI Review button renders on `/recipes/21`
- [x] Playwright: modal opens, loads, renders Claude Sonnet 4 response
- [x] Playwright: click inside content → modal stays open
- [x] Playwright: simulated drag from content → overlay → modal stays open (the bug fix)
- [x] Playwright: pure overlay click → closes
- [x] Playwright: × Close button → closes
- [ ] Manual: try real text-selection drag in browser
- [ ] Manual: verify edit page AI Review still works (uses same component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)