### PR TITLE
fix(recipe): mobile button row no longer overflows viewport

### DIFF
--- a/frontend/src/routes/recipes/[id]/+page.svelte
+++ b/frontend/src/routes/recipes/[id]/+page.svelte
@@ -1078,14 +1078,35 @@
 
 	/* Responsive */
 	@media (max-width: 640px) {
+		.page-container {
+			padding: var(--space-4);
+		}
+
 		.hero-content {
 			flex-direction: column;
 			gap: var(--space-4);
+			padding: var(--space-4);
 		}
 
 		.header-actions {
 			width: 100%;
 			justify-content: flex-start;
+			flex-wrap: wrap;
+			gap: var(--space-2);
+		}
+
+		.header-actions .btn-review,
+		.header-actions .btn-secondary,
+		.header-actions .btn-primary {
+			flex: 1 1 calc(50% - var(--space-1));
+			min-width: 0;
+			justify-content: center;
+			padding: 10px 12px;
+			font-size: 13px;
+		}
+
+		.header-actions .btn-ghost-danger {
+			flex: 0 0 auto;
 		}
 
 		.recipe-title {


### PR DESCRIPTION
## Summary
- Recipe view header had 5 actions in a nowrap flex row — on mobile, Brew This was clipped and Delete rendered offscreen
- Wrap action row into a 2-column grid below 640px; icon-only Delete sized to content
- Tighten page-container + hero-content padding on mobile

## Test plan
- [x] Playwright @ 320px (iPhone SE) → no overflow
- [x] Playwright @ 375px (iPhone) → no overflow, 2-col grid
- [x] Playwright @ 768px (tablet) → unchanged single row
- [x] Deployed to Pi (192.168.4.218), verified via real device viewport
- [ ] Manual: real iPhone Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)